### PR TITLE
chore: simplify home navigation structure

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,31 +2,21 @@ import React from 'react';
 import Header from './components/Header';
 import Hero from './components/Hero';
 import Concept from './components/Concept';
-import FeaturedJournal from './components/FeaturedJournal';
-import LatestJournal from './components/LatestJournal';
 import Profile from './components/Profile';
 import Works from './components/Works';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
 import WorksPage from './components/WorksPage';
-import JournalPage from './components/JournalPage';
-import FeaturedPage from './components/FeaturedPage';
 
-const getRoute = (): 'home' | 'works' | 'journal' | 'featured' => {
+const getRoute = (): 'home' | 'works' => {
   if (window.location.hash.startsWith('#/works')) {
     return 'works';
-  }
-  if (window.location.hash.startsWith('#/journal')) {
-    return 'journal';
-  }
-  if (window.location.hash.startsWith('#/featured')) {
-    return 'featured';
   }
   return 'home';
 };
 
 const App: React.FC = () => {
-  const [route, setRoute] = React.useState<'home' | 'works' | 'journal' | 'featured'>(getRoute);
+  const [route, setRoute] = React.useState<'home' | 'works'>(getRoute);
 
   React.useEffect(() => {
     const handleHashChange = () => setRoute(getRoute());
@@ -41,12 +31,6 @@ const App: React.FC = () => {
   if (route === 'works') {
     return <WorksPage />;
   }
-  if (route === 'journal') {
-    return <JournalPage />;
-  }
-  if (route === 'featured') {
-    return <FeaturedPage />;
-  }
 
   return (
     <div id="top" className="min-h-screen bg-stone-50 text-stone-800 selection:bg-earth-terra/30 selection:text-earth-terra">
@@ -54,8 +38,6 @@ const App: React.FC = () => {
       <main>
         <Hero />
         <Concept />
-        <FeaturedJournal />
-        <LatestJournal />
         <Profile />
         <Works />
         <Contact />

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,7 +12,6 @@ const Footer: React.FC = () => {
 
         <nav className="flex flex-wrap justify-center gap-6 md:gap-12 mb-12 text-sm tracking-widest uppercase">
           <a href="#about" className="hover:text-white transition-colors">About</a>
-          <a href="#journal" className="hover:text-white transition-colors">Journal</a>
           <a href="#works" className="hover:text-white transition-colors">Works</a>
           <a href="#contact" className="hover:text-white transition-colors">Contact</a>
         </nav>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { Menu, Search, Instagram, X } from 'lucide-react';
+import { Instagram, Menu, X } from 'lucide-react';
 import { NavItem } from '../types';
 
 const navItems: NavItem[] = [
   { label: 'About', href: '#about' },
-  { label: 'Journal', href: '#journal' },
   { label: 'Works', href: '#works' },
   { label: 'Contact', href: '#contact' },
 ];
@@ -44,10 +43,7 @@ const Header: React.FC = () => {
               {item.label}
             </a>
           ))}
-          <div className="flex items-center space-x-4 border-l border-stone-300 pl-6">
-            <a href="#journal" aria-label="記事フィルターへ" className="text-stone-500 hover:text-stone-900 transition-colors">
-              <Search size={18} />
-            </a>
+          <div className="flex items-center border-l border-stone-300 pl-6">
             <a
               href="https://www.instagram.com/?hl=ja"
               target="_blank"
@@ -82,10 +78,7 @@ const Header: React.FC = () => {
               {item.label}
             </a>
           ))}
-          <div className="flex justify-center space-x-6 pt-4">
-            <a href="#journal" aria-label="記事フィルターへ" onClick={() => setMobileMenuOpen(false)}>
-              <Search className="text-stone-500" />
-            </a>
+          <div className="flex justify-center pt-4">
             <a
               href="https://www.instagram.com/?hl=ja"
               target="_blank"

--- a/components/Works.tsx
+++ b/components/Works.tsx
@@ -4,7 +4,6 @@ type WorkItem = {
   title: string;
   type: string;
   summary: string;
-  href: string;
 };
 
 const workItems: WorkItem[] = [
@@ -12,59 +11,60 @@ const workItems: WorkItem[] = [
     title: '美容・ライフスタイル系メディア掲載',
     type: 'Beauty Media',
     summary: '美的、anan Beauty＋、CREA、Hanakoなどで美容・体験レポートを継続発信。',
-    href: '#/works',
   },
   {
     title: '新聞・雑誌・女性向け媒体での連載/寄稿',
     type: 'Editorial',
     summary: '日経x woman、シティリビングなどで、日常に寄り添う五感テーマの記事を掲載。',
-    href: '#/works',
   },
   {
     title: '旅行・ブログ領域の発信',
     type: 'Travel Blog',
     summary: 'トラベルコ「りかたんの五感美容旅」や著者ページで旅と美容の記録を継続掲載。',
-    href: '#/works',
   },
   {
     title: '音声メディアでの継続配信',
     type: 'Audio',
     summary: 'Voicyで美容健康を軸に、習慣・栄養・睡眠・セルフケアなどのテーマを継続発信。',
-    href: '#/works',
   },
   {
     title: 'インタビュー・外部掲載',
     type: 'Interview',
     summary: '伝統工芸、ヤマハ音楽教室アンバサダーなど、外部インタビュー・掲載実績を展開。',
-    href: '#/works',
   },
 ];
 
 const Works: React.FC = () => {
   return (
     <section id="works" className="py-24 md:py-32 px-6 max-w-screen-xl mx-auto">
-      <div className="flex items-end justify-between gap-6 mb-12 md:mb-16">
-        <div>
+      <div className="grid grid-cols-1 lg:grid-cols-[0.85fr_1.15fr] gap-12 lg:gap-16 items-start">
+        <div className="lg:sticky lg:top-28">
           <span className="block text-xs tracking-[0.3em] text-earth-sage uppercase mb-3">Works</span>
-          <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-wider">活動と実績</h2>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 md:gap-8">
-        {workItems.map((work) => (
+          <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-wider mb-6">活動と実績</h2>
+          <p className="text-sm md:text-base text-stone-600 leading-loose mb-8">
+            掲載媒体、連載、旅の取材、音声配信、インタビューをひとつの実績ページに集約しています。
+            詳細なリンクや今後追加する取材実績は、Worksページで確認できます。
+          </p>
           <a
-            key={work.title}
-            href={work.href}
-            target={work.href.startsWith('http') ? '_blank' : undefined}
-            rel={work.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-            className="group border border-stone-200 bg-stone-50 p-6 md:p-8 flex flex-col transition-all duration-300 hover:-translate-y-1 hover:shadow-lg hover:border-earth-terra/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
-            aria-label={`${work.title}の詳細へ移動`}
+            href="#/works"
+            className="inline-block px-8 py-3 bg-stone-800 text-stone-50 text-sm tracking-widest hover:bg-earth-terra transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
           >
-            <span className="text-xs tracking-widest uppercase text-earth-terra mb-4">{work.type}</span>
-            <h3 className="text-xl font-serif text-stone-900 mb-4 leading-relaxed">{work.title}</h3>
-            <p className="text-sm md:text-base text-stone-600 leading-loose">{work.summary}</p>
+            実績ページを見る
           </a>
-        ))}
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-5">
+          {workItems.map((work) => (
+            <article
+              key={work.title}
+              className="border border-stone-200 bg-stone-50 p-6 md:p-7"
+            >
+              <span className="text-xs tracking-widest uppercase text-earth-terra mb-4 block">{work.type}</span>
+              <h3 className="text-lg font-serif text-stone-900 mb-3 leading-relaxed">{work.title}</h3>
+              <p className="text-sm text-stone-600 leading-loose">{work.summary}</p>
+            </article>
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/docs/02-page-structure.md
+++ b/docs/02-page-structure.md
@@ -6,45 +6,46 @@
 - Current map:
   - `/` Home (single page)
   - `/#concept` Concept
-  - `/#featured` Featured Journal
-  - `/#journal` Latest Journal
   - `/#about` Profile
   - `/#works` Works
   - `/#contact` Contact
+  - `/#/works` Works Page
 
 ## 2. Page Definitions
 ### Page: `/`
 - Goal: 五感美容の世界観と実績を短時間で伝える
-- Primary CTA: `記事一覧を見る`（Latest Journal末尾）
+- Primary CTA: `実績ページを見る`（Works）
 - Secondary CTA:
-  - `VIEW ALL JOURNAL`（Featured -> Journal）
   - `詳しいプロフィール・実績を見る`
 - Main sections (top to bottom):
   1. Header (fixed nav)
   2. Hero
   3. Concept (`#concept`)
-  4. Featured Journal (`#featured`)
-  5. Latest Journal (`#journal`)
-  6. Profile (`#about`)
-  7. Works (`#works`)
-  8. Contact (`#contact`)
-  9. Footer
+  4. Profile (`#about`)
+  5. Works (`#works`)
+  6. Contact (`#contact`)
+  7. Footer
 - Required assets:
   - Hero image
-  - Featured article images x3
-  - Latest article images x3
   - Profile image x1
 - Success condition:
   - 主要CTAクリックが継続発生
   - Profileセクションまでの到達率が一定以上
+
+### Page: `/#/works`
+- Goal: 掲載実績、外部リンク、取材実績を集約して確認できるようにする
+- Primary CTA: 各外部掲載リンク
+- Main sections:
+  1. Portfolio Links hero
+  2. Featured
+  3. 活動カテゴリ
+  4. リンク集
 
 ## 3. Component Notes
 - Reusable components:
   - [Header.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Header.tsx)
   - [Hero.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Hero.tsx)
   - [Concept.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Concept.tsx)
-  - [FeaturedJournal.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/FeaturedJournal.tsx)
-  - [LatestJournal.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/LatestJournal.tsx)
   - [Profile.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Profile.tsx)
   - [Works.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Works.tsx)
   - [Contact.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Contact.tsx)

--- a/docs/06-navigation-and-structure-spec.md
+++ b/docs/06-navigation-and-structure-spec.md
@@ -7,40 +7,28 @@
 ## 2. Route Map
 - `#` or no hash: Home（1ページ構成）
 - `#/works`: 活動と実績の専用ページ
-- `#/journal`: 記事一覧の専用ページ
-- `#/featured`: 特集一覧の専用ページ
 
 ## 3. Home Structure (Top to Bottom)
 1. Header (`#top` 起点)
 2. Hero
 3. Concept
-4. Featured Journal
-5. Latest Journal (`#journal`)
-6. Profile (`#about`)
-7. Works (`#works`)
-8. Contact (`#contact`)
-9. Footer
+4. Profile (`#about`)
+5. Works (`#works`)
+6. Contact (`#contact`)
+7. Footer
 
 ## 4. Primary Navigation
 - Header / Footer のグローバルナビはセクションアンカーを使用する。
   - `About` -> `#about`
-  - `Journal` -> `#journal`
   - `Works` -> `#works`
   - `Contact` -> `#contact`
 
 ## 5. CTA Rules (Current)
-- Featured Journal
-  - 各カード: `#/featured`
-  - CTA: `特集一覧を見る`
-  - Destination: `#/featured`
-- Latest Journal
-  - 各記事カード: `#/journal`
-  - セクション末尾ボタン: `#/journal`
 - Profile
   - CTA: `詳しいプロフィール・実績を見る →`
   - Destination: `#/works`
 - Works
-  - 3カードすべてカード全体クリックで遷移
+  - セクション内の主CTAのみで遷移
   - Destination: `#/works`
 
 ## 6. Duplicate-CTA Policy
@@ -53,13 +41,10 @@
 ## 7. Component Ownership
 - Routing switch: [App.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/App.tsx)
 - Home sections:
-  - [components/FeaturedJournal.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/FeaturedJournal.tsx)
-  - [components/LatestJournal.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/LatestJournal.tsx)
   - [components/Profile.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Profile.tsx)
   - [components/Works.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/Works.tsx)
 - Dedicated pages:
   - [components/WorksPage.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/WorksPage.tsx)
-  - [components/JournalPage.tsx](/c:/Users/yutaz/dev/sensoria-portfolio/components/JournalPage.tsx)
 
 ## 8. Change Checklist
 - 新しいCTAを追加する場合:


### PR DESCRIPTION
## Summary
- Simplify the public site flow to Home -> Works -> Contact
- Remove Journal and Featured from the main route/navigation surface
- Convert the Home Works section from many duplicate links into one clear CTA
- Update structure docs to match the simplified navigation

## Testing
- npm run build