### PR TITLE
chore: add issue15 source audit starter

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -7,8 +7,12 @@ import Works from './components/Works';
 import Contact from './components/Contact';
 import Footer from './components/Footer';
 import WorksPage from './components/WorksPage';
+import Issue15AuditPage from './components/Issue15AuditPage';
 
-const getRoute = (): 'home' | 'works' => {
+const getRoute = (): 'home' | 'works' | 'issue15Audit' => {
+  if (window.location.hash.startsWith('#/issue15-audit')) {
+    return 'issue15Audit';
+  }
   if (window.location.hash.startsWith('#/works')) {
     return 'works';
   }
@@ -16,7 +20,7 @@ const getRoute = (): 'home' | 'works' => {
 };
 
 const App: React.FC = () => {
-  const [route, setRoute] = React.useState<'home' | 'works'>(getRoute);
+  const [route, setRoute] = React.useState<'home' | 'works' | 'issue15Audit'>(getRoute);
 
   React.useEffect(() => {
     const handleHashChange = () => setRoute(getRoute());
@@ -30,6 +34,10 @@ const App: React.FC = () => {
 
   if (route === 'works') {
     return <WorksPage />;
+  }
+
+  if (route === 'issue15Audit') {
+    return <Issue15AuditPage />;
   }
 
   return (

--- a/components/Issue15AuditPage.tsx
+++ b/components/Issue15AuditPage.tsx
@@ -1,0 +1,224 @@
+import React from 'react';
+import { AlertTriangle, CheckCircle2, CircleDashed, ExternalLink, FileSearch } from 'lucide-react';
+import {
+  type AuditDecision,
+  type AuthorCheckStatus,
+  type ExtractionStatus,
+  type Issue15AuditCategory,
+  issue15SourceCandidates,
+  type UrlCheckStatus,
+} from '../data/issue15SourceCandidates';
+
+const categoryLabels: Record<Issue15AuditCategory, string> = {
+  museum: '美術館',
+  hotel: 'ホテル',
+  traditional_craft: '伝統工芸',
+  media_history: '雑誌/媒体履歴',
+  reference: '参照',
+};
+
+const urlStatusLabels: Record<UrlCheckStatus, string> = {
+  unchecked: '未確認',
+  valid: '有効',
+  redirected: 'リダイレクト',
+  blocked: '閲覧制限',
+  invalid: '無効',
+  needs_manual_check: '要手動確認',
+};
+
+const authorStatusLabels: Record<AuthorCheckStatus, string> = {
+  unchecked: '未確認',
+  confirmed: '本人確認済み',
+  unclear: '不明',
+  not_author: '本人記事ではない',
+};
+
+const extractionStatusLabels: Record<ExtractionStatus, string> = {
+  not_started: '未抽出',
+  candidate_found: '候補あり',
+  no_target_found: '対象なし',
+  normalized: '正規化済み',
+  approved: '採用',
+  rejected: '除外',
+};
+
+const decisionLabels: Record<AuditDecision, string> = {
+  unreviewed: '未判定',
+  keep_candidate: '候補維持',
+  hold: '保留',
+  exclude: '除外',
+  approved: '採用',
+};
+
+const getDecisionClassName = (decision: AuditDecision): string => {
+  if (decision === 'approved') {
+    return 'border-emerald-200 bg-emerald-50 text-emerald-800';
+  }
+  if (decision === 'exclude') {
+    return 'border-rose-200 bg-rose-50 text-rose-800';
+  }
+  if (decision === 'hold') {
+    return 'border-amber-200 bg-amber-50 text-amber-800';
+  }
+  if (decision === 'keep_candidate') {
+    return 'border-sky-200 bg-sky-50 text-sky-800';
+  }
+  return 'border-stone-200 bg-stone-100 text-stone-600';
+};
+
+const getDecisionIcon = (decision: AuditDecision): React.ReactNode => {
+  if (decision === 'approved') {
+    return <CheckCircle2 className="h-4 w-4" aria-hidden="true" />;
+  }
+  if (decision === 'exclude' || decision === 'hold') {
+    return <AlertTriangle className="h-4 w-4" aria-hidden="true" />;
+  }
+  return <CircleDashed className="h-4 w-4" aria-hidden="true" />;
+};
+
+const StatusPill: React.FC<{ label: string }> = ({ label }) => (
+  <span className="inline-flex items-center border border-stone-200 bg-white px-2.5 py-1 text-[11px] tracking-widest text-stone-600">
+    {label}
+  </span>
+);
+
+const Issue15AuditPage: React.FC = () => {
+  const total = issue15SourceCandidates.length;
+  const unchecked = issue15SourceCandidates.filter((item) => item.urlStatus === 'unchecked').length;
+  const confirmed = issue15SourceCandidates.filter((item) => item.authorStatus === 'confirmed').length;
+  const pending = issue15SourceCandidates.filter((item) => item.decision === 'unreviewed').length;
+
+  return (
+    <div className="min-h-screen bg-stone-50 text-stone-800">
+      <header className="sticky top-0 z-20 border-b border-stone-200 bg-stone-50/95 backdrop-blur">
+        <div className="mx-auto flex max-w-screen-xl items-center justify-between px-6 py-5">
+          <a href="#/works" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-earth-terra">
+            Works
+          </a>
+          <p className="text-sm tracking-widest text-stone-500">Issue #15 Audit</p>
+          <a href="#" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-earth-terra">
+            Top
+          </a>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-screen-xl px-6 py-12 md:py-16">
+        <section className="mb-10 grid grid-cols-1 gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-end">
+          <div>
+            <span className="mb-4 block text-xs uppercase tracking-[0.3em] text-earth-sage">Source Audit</span>
+            <h1 className="font-serif text-3xl leading-tight text-stone-900 md:text-5xl">
+              #15 採用前の
+              <br />
+              確認用リンク集
+            </h1>
+          </div>
+          <p className="text-sm leading-loose text-stone-600 md:text-base">
+            このページは本番掲載前の確認ビューです。URLの生存確認、本人記事確認、抽出候補、採用判断を分けて記録し、
+            根拠が弱い情報を実績ページへ混ぜないために使います。
+          </p>
+        </section>
+
+        <section className="mb-10 grid grid-cols-2 gap-3 md:grid-cols-4">
+          {[
+            ['候補URL', total],
+            ['URL未確認', unchecked],
+            ['本人確認済み', confirmed],
+            ['未判定', pending],
+          ].map(([label, value]) => (
+            <div key={label} className="border border-stone-200 bg-white p-5">
+              <span className="block font-serif text-3xl text-earth-gold">{value}</span>
+              <span className="mt-2 block text-xs tracking-widest text-stone-500">{label}</span>
+            </div>
+          ))}
+        </section>
+
+        <section className="mb-8 border border-stone-200 bg-white p-5 md:p-6">
+          <div className="flex items-start gap-3">
+            <FileSearch className="mt-1 h-5 w-5 flex-none text-earth-terra" aria-hidden="true" />
+            <div>
+              <h2 className="font-serif text-xl text-stone-900">チェックランの順序</h2>
+              <p className="mt-2 text-sm leading-loose text-stone-600">
+                1. URL生存確認 → 2. 本人記事確認 → 3. 抽出候補作成 → 4. 正規化 → 5. 採用判定。
+                採用判定が終わるまで、Works本番表示データには反映しません。
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="space-y-4">
+          {issue15SourceCandidates.map((item) => (
+            <article key={item.id} className="border border-stone-200 bg-white p-5 md:p-6">
+              <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_220px]">
+                <div>
+                  <div className="mb-3 flex flex-wrap gap-2">
+                    {item.expectedCategories.map((category) => (
+                      <StatusPill key={category} label={categoryLabels[category]} />
+                    ))}
+                  </div>
+                  <h3 className="font-serif text-xl leading-relaxed text-stone-900">{item.title}</h3>
+                  <p className="mt-2 text-xs tracking-widest text-stone-400">{item.sourceGroup}</p>
+                  <a
+                    href={item.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-4 inline-flex items-center gap-2 break-all text-sm text-earth-terra transition-colors hover:text-stone-900"
+                  >
+                    {item.url}
+                    <ExternalLink className="h-4 w-4 flex-none" aria-hidden="true" />
+                  </a>
+                </div>
+
+                <div className={`flex h-fit items-center gap-2 border px-3 py-2 text-sm ${getDecisionClassName(item.decision)}`}>
+                  {getDecisionIcon(item.decision)}
+                  <span className="tracking-widest">{decisionLabels[item.decision]}</span>
+                </div>
+              </div>
+
+              <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-3">
+                <div className="border border-stone-100 bg-stone-50 p-3">
+                  <p className="text-[11px] tracking-widest text-stone-400">URL</p>
+                  <p className="mt-1 text-sm text-stone-700">{urlStatusLabels[item.urlStatus]}</p>
+                </div>
+                <div className="border border-stone-100 bg-stone-50 p-3">
+                  <p className="text-[11px] tracking-widest text-stone-400">AUTHOR</p>
+                  <p className="mt-1 text-sm text-stone-700">{authorStatusLabels[item.authorStatus]}</p>
+                </div>
+                <div className="border border-stone-100 bg-stone-50 p-3">
+                  <p className="text-[11px] tracking-widest text-stone-400">EXTRACTION</p>
+                  <p className="mt-1 text-sm text-stone-700">{extractionStatusLabels[item.extractionStatus]}</p>
+                </div>
+              </div>
+
+              <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_180px]">
+                <div>
+                  <p className="text-[11px] tracking-widest text-stone-400">MEMO</p>
+                  <p className="mt-2 text-sm leading-loose text-stone-600">{item.notes}</p>
+                </div>
+                <div>
+                  <p className="text-[11px] tracking-widest text-stone-400">CHECKED AT</p>
+                  <p className="mt-2 text-sm text-stone-600">{item.checkedAt ?? '未実施'}</p>
+                </div>
+              </div>
+
+              {item.extractedNames.length > 0 && (
+                <div className="mt-5">
+                  <p className="text-[11px] tracking-widest text-stone-400">EXTRACTED NAMES</p>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    {item.extractedNames.map((name) => (
+                      <span key={name} className="border border-stone-200 bg-stone-50 px-3 py-1 text-sm text-stone-700">
+                        {name}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+            </article>
+          ))}
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default Issue15AuditPage;
+

--- a/components/Issue15AuditPage.tsx
+++ b/components/Issue15AuditPage.tsx
@@ -5,9 +5,12 @@ import {
   type AuthorCheckStatus,
   type ExtractionStatus,
   type Issue15AuditCategory,
+  type Issue15SourceCandidate,
   issue15SourceCandidates,
   type UrlCheckStatus,
 } from '../data/issue15SourceCandidates';
+
+const storageKey = 'issue15-source-audit-state-v1';
 
 const categoryLabels: Record<Issue15AuditCategory, string> = {
   museum: '美術館',
@@ -82,11 +85,76 @@ const StatusPill: React.FC<{ label: string }> = ({ label }) => (
   </span>
 );
 
+type SelectFieldProps<Value extends string> = {
+  label: string;
+  value: Value;
+  labels: Record<Value, string>;
+  onChange: (value: Value) => void;
+};
+
+const SelectField = <Value extends string>({ label, value, labels, onChange }: SelectFieldProps<Value>) => (
+  <label className="block border border-stone-100 bg-stone-50 p-3">
+    <span className="block text-[11px] tracking-widest text-stone-400">{label}</span>
+    <select
+      value={value}
+      onChange={(event) => onChange(event.target.value as Value)}
+      className="mt-2 w-full border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+    >
+      {Object.entries(labels).map(([optionValue, optionLabel]) => (
+        <option key={optionValue} value={optionValue}>
+          {optionLabel as string}
+        </option>
+      ))}
+    </select>
+  </label>
+);
+
+const loadCandidates = (): Issue15SourceCandidate[] => {
+  try {
+    const stored = window.localStorage.getItem(storageKey);
+    if (!stored) {
+      return issue15SourceCandidates;
+    }
+
+    const savedCandidates = JSON.parse(stored) as Issue15SourceCandidate[];
+    const savedById = new Map(savedCandidates.map((item) => [item.id, item]));
+
+    return issue15SourceCandidates.map((candidate) => ({
+      ...candidate,
+      ...savedById.get(candidate.id),
+      expectedCategories: candidate.expectedCategories,
+      title: candidate.title,
+      url: candidate.url,
+      sourceGroup: candidate.sourceGroup,
+    }));
+  } catch {
+    return issue15SourceCandidates;
+  }
+};
+
 const Issue15AuditPage: React.FC = () => {
-  const total = issue15SourceCandidates.length;
-  const unchecked = issue15SourceCandidates.filter((item) => item.urlStatus === 'unchecked').length;
-  const confirmed = issue15SourceCandidates.filter((item) => item.authorStatus === 'confirmed').length;
-  const pending = issue15SourceCandidates.filter((item) => item.decision === 'unreviewed').length;
+  const [candidates, setCandidates] = React.useState<Issue15SourceCandidate[]>(loadCandidates);
+
+  React.useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(candidates));
+  }, [candidates]);
+
+  const updateCandidate = <Key extends keyof Issue15SourceCandidate>(
+    id: string,
+    key: Key,
+    value: Issue15SourceCandidate[Key],
+  ) => {
+    setCandidates((current) => current.map((item) => (item.id === id ? { ...item, [key]: value } : item)));
+  };
+
+  const markCheckedNow = (id: string) => {
+    updateCandidate(id, 'checkedAt', new Date().toISOString().slice(0, 10));
+  };
+
+  const total = candidates.length;
+  const unchecked = candidates.filter((item) => item.urlStatus === 'unchecked').length;
+  const confirmed = candidates.filter((item) => item.authorStatus === 'confirmed').length;
+  const pending = candidates.filter((item) => item.decision === 'unreviewed').length;
 
   return (
     <div className="min-h-screen bg-stone-50 text-stone-800">
@@ -114,7 +182,7 @@ const Issue15AuditPage: React.FC = () => {
           </div>
           <p className="text-sm leading-loose text-stone-600 md:text-base">
             このページは本番掲載前の確認ビューです。URLの生存確認、本人記事確認、抽出候補、採用判断を分けて記録し、
-            根拠が弱い情報を実績ページへ混ぜないために使います。
+            根拠が弱い情報を実績ページへ混ぜないために使います。画面上の変更はこのブラウザに保存されます。
           </p>
         </section>
 
@@ -146,7 +214,7 @@ const Issue15AuditPage: React.FC = () => {
         </section>
 
         <section className="space-y-4">
-          {issue15SourceCandidates.map((item) => (
+          {candidates.map((item) => (
             <article key={item.id} className="border border-stone-200 bg-white p-5 md:p-6">
               <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_220px]">
                 <div>
@@ -175,28 +243,62 @@ const Issue15AuditPage: React.FC = () => {
               </div>
 
               <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-3">
+                <SelectField
+                  label="URL"
+                  value={item.urlStatus}
+                  labels={urlStatusLabels}
+                  onChange={(value) => updateCandidate(item.id, 'urlStatus', value)}
+                />
+                <SelectField
+                  label="AUTHOR"
+                  value={item.authorStatus}
+                  labels={authorStatusLabels}
+                  onChange={(value) => updateCandidate(item.id, 'authorStatus', value)}
+                />
+                <SelectField
+                  label="EXTRACTION"
+                  value={item.extractionStatus}
+                  labels={extractionStatusLabels}
+                  onChange={(value) => updateCandidate(item.id, 'extractionStatus', value)}
+                />
+              </div>
+
+              <div className="mt-5 grid grid-cols-1 gap-3 md:grid-cols-[1fr_220px]">
+                <SelectField
+                  label="DECISION"
+                  value={item.decision}
+                  labels={decisionLabels}
+                  onChange={(value) => updateCandidate(item.id, 'decision', value)}
+                />
                 <div className="border border-stone-100 bg-stone-50 p-3">
-                  <p className="text-[11px] tracking-widest text-stone-400">URL</p>
-                  <p className="mt-1 text-sm text-stone-700">{urlStatusLabels[item.urlStatus]}</p>
-                </div>
-                <div className="border border-stone-100 bg-stone-50 p-3">
-                  <p className="text-[11px] tracking-widest text-stone-400">AUTHOR</p>
-                  <p className="mt-1 text-sm text-stone-700">{authorStatusLabels[item.authorStatus]}</p>
-                </div>
-                <div className="border border-stone-100 bg-stone-50 p-3">
-                  <p className="text-[11px] tracking-widest text-stone-400">EXTRACTION</p>
-                  <p className="mt-1 text-sm text-stone-700">{extractionStatusLabels[item.extractionStatus]}</p>
+                  <p className="text-[11px] tracking-widest text-stone-400">CHECKED AT</p>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      type="date"
+                      value={item.checkedAt ?? ''}
+                      onChange={(event) => updateCandidate(item.id, 'checkedAt', event.target.value || null)}
+                      className="min-w-0 flex-1 border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => markCheckedNow(item.id)}
+                      className="border border-stone-300 bg-white px-3 py-2 text-xs tracking-widest text-stone-600 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                    >
+                      今日
+                    </button>
+                  </div>
                 </div>
               </div>
 
-              <div className="mt-5 grid grid-cols-1 gap-4 lg:grid-cols-[1fr_180px]">
+              <div className="mt-5">
                 <div>
                   <p className="text-[11px] tracking-widest text-stone-400">MEMO</p>
-                  <p className="mt-2 text-sm leading-loose text-stone-600">{item.notes}</p>
-                </div>
-                <div>
-                  <p className="text-[11px] tracking-widest text-stone-400">CHECKED AT</p>
-                  <p className="mt-2 text-sm text-stone-600">{item.checkedAt ?? '未実施'}</p>
+                  <textarea
+                    value={item.notes}
+                    onChange={(event) => updateCandidate(item.id, 'notes', event.target.value)}
+                    rows={3}
+                    className="mt-2 w-full border border-stone-200 bg-stone-50 px-3 py-2 text-sm leading-loose text-stone-700 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+                  />
                 </div>
               </div>
 
@@ -221,4 +323,3 @@ const Issue15AuditPage: React.FC = () => {
 };
 
 export default Issue15AuditPage;
-

--- a/components/Issue15AuditPage.tsx
+++ b/components/Issue15AuditPage.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { AlertTriangle, CheckCircle2, CircleDashed, ExternalLink, FileSearch } from 'lucide-react';
+import { AlertTriangle, CheckCircle2, CircleDashed, Copy, Download, ExternalLink, FileSearch, Upload } from 'lucide-react';
 import {
   type AuditDecision,
   type AuthorCheckStatus,
@@ -134,6 +134,8 @@ const loadCandidates = (): Issue15SourceCandidate[] => {
 
 const Issue15AuditPage: React.FC = () => {
   const [candidates, setCandidates] = React.useState<Issue15SourceCandidate[]>(loadCandidates);
+  const [importText, setImportText] = React.useState('');
+  const [feedback, setFeedback] = React.useState('');
 
   React.useEffect(() => {
     window.localStorage.setItem(storageKey, JSON.stringify(candidates));
@@ -149,6 +151,65 @@ const Issue15AuditPage: React.FC = () => {
 
   const markCheckedNow = (id: string) => {
     updateCandidate(id, 'checkedAt', new Date().toISOString().slice(0, 10));
+  };
+
+  const exportJson = React.useMemo(() => JSON.stringify(candidates, null, 2), [candidates]);
+
+  const copyExportJson = async () => {
+    try {
+      await window.navigator.clipboard.writeText(exportJson);
+      setFeedback('JSONをクリップボードへコピーしました。');
+    } catch {
+      setFeedback('コピーできませんでした。下のJSONを手動でコピーしてください。');
+    }
+  };
+
+  const downloadExportJson = () => {
+    const blob = new Blob([exportJson], { type: 'application/json' });
+    const url = window.URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `issue15-source-audit-${new Date().toISOString().slice(0, 10)}.json`;
+    link.click();
+    window.URL.revokeObjectURL(url);
+    setFeedback('JSONファイルを保存しました。');
+  };
+
+  const importJson = () => {
+    try {
+      const parsed = JSON.parse(importText) as unknown;
+      if (!Array.isArray(parsed)) {
+        setFeedback('インポートできませんでした。JSON配列を貼り付けてください。');
+        return;
+      }
+
+      const importedById = new Map(
+        parsed
+          .filter((item): item is Partial<Issue15SourceCandidate> & { id: string } => {
+            return Boolean(item && typeof item === 'object' && 'id' in item && typeof item.id === 'string');
+          })
+          .map((item) => [item.id, item]),
+      );
+
+      if (importedById.size === 0) {
+        setFeedback('インポートできませんでした。候補IDを含むJSONを貼り付けてください。');
+        return;
+      }
+
+      setCandidates((current) =>
+        current.map((candidate) => ({
+          ...candidate,
+          ...importedById.get(candidate.id),
+          expectedCategories: candidate.expectedCategories,
+          title: candidate.title,
+          url: candidate.url,
+          sourceGroup: candidate.sourceGroup,
+        })),
+      );
+      setFeedback(`${importedById.size}件の候補データを取り込みました。`);
+    } catch {
+      setFeedback('インポートできませんでした。JSONの形式を確認してください。');
+    }
   };
 
   const total = candidates.length;
@@ -209,6 +270,64 @@ const Issue15AuditPage: React.FC = () => {
                 1. URL生存確認 → 2. 本人記事確認 → 3. 抽出候補作成 → 4. 正規化 → 5. 採用判定。
                 採用判定が終わるまで、Works本番表示データには反映しません。
               </p>
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-8 border border-stone-200 bg-white p-5 md:p-6">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <div>
+              <h2 className="font-serif text-xl text-stone-900">Export</h2>
+              <p className="mt-2 text-sm leading-loose text-stone-600">
+                更新済みの確認結果をJSONとして取り出します。次回作業やデータファイルへの反映に使います。
+              </p>
+              <div className="mt-4 flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={copyExportJson}
+                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                >
+                  <Copy className="h-4 w-4" aria-hidden="true" />
+                  JSONをコピー
+                </button>
+                <button
+                  type="button"
+                  onClick={downloadExportJson}
+                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                >
+                  <Download className="h-4 w-4" aria-hidden="true" />
+                  JSONを保存
+                </button>
+              </div>
+              <textarea
+                readOnly
+                value={exportJson}
+                rows={8}
+                className="mt-4 w-full border border-stone-200 bg-stone-50 px-3 py-2 font-mono text-xs leading-relaxed text-stone-600 outline-none"
+              />
+            </div>
+
+            <div>
+              <h2 className="font-serif text-xl text-stone-900">Import</h2>
+              <p className="mt-2 text-sm leading-loose text-stone-600">
+                保存済みJSONを貼り付けると、このブラウザ上の確認状態へ復元できます。
+              </p>
+              <textarea
+                value={importText}
+                onChange={(event) => setImportText(event.target.value)}
+                rows={8}
+                placeholder="保存済みのJSONを貼り付け"
+                className="mt-4 w-full border border-stone-200 bg-stone-50 px-3 py-2 font-mono text-xs leading-relaxed text-stone-700 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+              />
+              <button
+                type="button"
+                onClick={importJson}
+                className="mt-3 inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+              >
+                <Upload className="h-4 w-4" aria-hidden="true" />
+                JSONを取り込む
+              </button>
+              {feedback && <p className="mt-3 text-sm leading-loose text-stone-600">{feedback}</p>}
             </div>
           </div>
         </section>

--- a/data/issue15SourceCandidates.ts
+++ b/data/issue15SourceCandidates.ts
@@ -1,0 +1,203 @@
+export type Issue15AuditCategory =
+  | 'museum'
+  | 'hotel'
+  | 'traditional_craft'
+  | 'media_history'
+  | 'reference';
+
+export type UrlCheckStatus =
+  | 'unchecked'
+  | 'valid'
+  | 'redirected'
+  | 'blocked'
+  | 'invalid'
+  | 'needs_manual_check';
+
+export type AuthorCheckStatus =
+  | 'unchecked'
+  | 'confirmed'
+  | 'unclear'
+  | 'not_author';
+
+export type ExtractionStatus =
+  | 'not_started'
+  | 'candidate_found'
+  | 'no_target_found'
+  | 'normalized'
+  | 'approved'
+  | 'rejected';
+
+export type AuditDecision = 'unreviewed' | 'keep_candidate' | 'hold' | 'exclude' | 'approved';
+
+export type Issue15SourceCandidate = {
+  id: string;
+  title: string;
+  url: string;
+  sourceGroup: string;
+  expectedCategories: Issue15AuditCategory[];
+  urlStatus: UrlCheckStatus;
+  authorStatus: AuthorCheckStatus;
+  extractionStatus: ExtractionStatus;
+  decision: AuditDecision;
+  extractedNames: string[];
+  checkedAt: string | null;
+  notes: string;
+};
+
+export const issue15SourceCandidates: Issue15SourceCandidate[] = [
+  {
+    id: 'tour-rikatan-index',
+    title: 'りかたんの五感美容旅 | トラベルコ',
+    url: 'https://www.tour.ne.jp/blog/rikatan/',
+    sourceGroup: '旅ブログ',
+    expectedCategories: ['museum', 'hotel', 'traditional_craft'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '著者配下の記事一覧として扱い、個別記事URLへ展開する前の入口候補。',
+  },
+  {
+    id: 'rakukatsu-author',
+    title: '楽活 著者ページ',
+    url: 'https://rakukatsu.jp/author/takahashi-rika',
+    sourceGroup: '旅ブログ',
+    expectedCategories: ['museum', 'hotel', 'traditional_craft'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '著者ページ確認後、本人記事の個別URLのみ抽出対象にする。',
+  },
+  {
+    id: 'biteki-wellness-plan',
+    title: 'GWや夏休みはどう過ごす？ 1泊2日のウェルネスプラン | 美的.com',
+    url: 'https://www.biteki.com/life-style/others/1661397',
+    sourceGroup: '美容/ライフ',
+    expectedCategories: ['hotel'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: 'リンク集管理対象URL。ホテル名抽出候補として確認する。',
+  },
+  {
+    id: 'biteki-kirishima-trip',
+    title: '美肌整う鹿児島県・霧島の温泉旅 | 美的.com',
+    url: 'https://www.biteki.com/life-style/others/1660535',
+    sourceGroup: '美容/ライフ',
+    expectedCategories: ['hotel'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: 'リンク集管理対象URL。ホテル名やエリア情報の根拠として使えるか確認する。',
+  },
+  {
+    id: 'biteki-nail-oil',
+    title: '14のおすすめ ネイルオイル | 美的.com',
+    url: 'https://www.biteki.com/nail/nail-howto/292503',
+    sourceGroup: '美容/ライフ',
+    expectedCategories: ['reference'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '3カテゴリの直接候補ではないため、本人記事確認後も原則は参照扱い。',
+  },
+  {
+    id: 'girlsartalk-traditional-craft',
+    title: '伝統工芸インタビュー',
+    url: 'https://girlsartalk.com/column/16874.html',
+    sourceGroup: 'その他',
+    expectedCategories: ['traditional_craft'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '404やURL移転の可能性も含めて、本文と本人掲載の両方を確認する。',
+  },
+  {
+    id: 'woman-nikkei-stationery-pr',
+    title: '書き残すことで気持ちがスッキリする手帳活用術 | 日経xwoman',
+    url: 'https://woman.nikkei.com/atcl/cons/051300011/101300034/?P=2',
+    sourceGroup: '新聞/雑誌',
+    expectedCategories: ['media_history'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '雑誌掲載履歴・寄稿実績側の候補。3カテゴリ抽出には混ぜない。',
+  },
+  {
+    id: 'woman-nikkei-calendar',
+    title: '卓上カレンダーの活用法 | 日経xwoman',
+    url: 'https://woman.nikkei.com/atcl/doors/wol/magazine/15/113000009/042000022/',
+    sourceGroup: '新聞/雑誌',
+    expectedCategories: ['media_history'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '雑誌掲載履歴側の候補。時期と掲載種別を後で確認する。',
+  },
+  {
+    id: 'city-living-profile',
+    title: '日常に五感のスイッチを | シティリビングWeb',
+    url: 'https://city.living.jp/citymate/citymate415/',
+    sourceGroup: '新聞/雑誌',
+    expectedCategories: ['media_history'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '本人ページ導線として有効か確認する。',
+  },
+  {
+    id: 'city-living-yokohama-ebook',
+    title: 'シティリビング横浜版',
+    url: 'https://book.living.jp/ebooks/cityliving/yokohama/20190208/index_h5.html',
+    sourceGroup: '新聞/雑誌',
+    expectedCategories: ['media_history'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '媒体掲載履歴候補。本人掲載箇所を確認できる場合のみ採用候補にする。',
+  },
+  {
+    id: 'yamaha-ambassador',
+    title: 'ヤマハ音楽教室アンバサダーインタビュー',
+    url: 'https://www.yamaha-ongaku.com/music-school/why_yamaha/ambassador/article08.html',
+    sourceGroup: 'その他',
+    expectedCategories: ['reference'],
+    urlStatus: 'unchecked',
+    authorStatus: 'unchecked',
+    extractionStatus: 'not_started',
+    decision: 'unreviewed',
+    extractedNames: [],
+    checkedAt: null,
+    notes: '実績根拠候補。3カテゴリや雑誌掲載履歴とは分けて扱う。',
+  },
+];
+

--- a/docs/07-issue15-data-collection-rules.md
+++ b/docs/07-issue15-data-collection-rules.md
@@ -1,0 +1,98 @@
+# Issue #15 Data Collection Rules (2026-03-14)
+
+## 1. Purpose
+- 本ドキュメントは、Issue #15 のデータ収集でノイズ混入を防ぐための「サイト別抽出ルール」を定義する。
+- 抽出対象は次の3カテゴリのみ。
+  - 美術館名
+  - ホテル名
+  - 伝統工芸品名
+
+## 2. Collection Flow (Visual)
+```text
+[URL candidate]
+      |
+      v
+[Is domain in allowlist?] -- No --> [Drop]
+      |
+     Yes
+      |
+      v
+[Is it author-owned scope URL?] -- No --> [Drop]
+      |
+     Yes
+      |
+      v
+[Is target entity in text?]
+  - Museum name
+  - Hotel name
+  - Traditional craft item name
+      |
+   No v
+   [Keep as reference only]
+      |
+   Yes
+      |
+      v
+[Normalize name + attach evidence URL]
+      |
+      v
+[Store in dataset]
+```
+
+## 3. Site Rules Matrix
+| Site | Author / Ownership Validation | Allowed URL Scope | Extract Targets | Exclude |
+|---|---|---|---|---|
+| `www.tour.ne.jp` | 著者ページが `blog/rikatan` であること | `https://www.tour.ne.jp/blog/rikatan/` 配下 | 美術館名 / ホテル名 / 伝統工芸品名 | 著者配下外URL、広告パーツ由来テキスト |
+| `rakukatsu.jp` | 著者ページが `author/takahashi-rika` であること | `https://rakukatsu.jp/author/takahashi-rika` 配下 | 美術館名 / ホテル名 / 伝統工芸品名 | 著者配下外URL、関連記事ウィジェットのみの情報 |
+| `www.biteki.com` | 本人寄稿記事である根拠（リンク集管理対象） | リンク集で管理中の個別記事URLのみ | 主にホテル名（旅記事） | サイト全体の一般記事巡回 |
+| `girlsartalk.com` | 本人掲載と紐づくURLのみ | リンク集に登録済みURL、またはその代替URL確定後 | 主に伝統工芸品名 | 代替URL未確定の記事、404 URL |
+| `woman.nikkei.com` | 本人導線（アンバサダー/寄稿）であること | リンク集管理対象URLのみ | 補助情報（雑誌掲載履歴側） | サイト横断クロール |
+| `city.living.jp` | 本人ページ導線であること | リンク集管理対象URLのみ | 補助情報（雑誌掲載履歴側） | サイト横断クロール |
+| `www.yamaha-ongaku.com` | 対象インタビューURLであること | 登録済みインタビューURLのみ | 補助情報（実績根拠） | 他ページへの拡張探索 |
+
+## 4. Extraction Rule by Category
+### 4.1 美術館名
+- 「◯◯美術館」の固有名詞を優先抽出する。
+- 例: `国立西洋美術館`、`オルセー美術館`
+- 展覧会名のみで施設名がない場合は「候補」扱いにする。
+
+### 4.2 ホテル名
+- 「ホテル」を含む固有施設名を抽出する。
+- 例: `ホテルインディゴ東京渋谷`、`フォーシーズンズホテル東京大手町`
+- レストラン名のみはホテル名と分離して扱う。
+
+### 4.3 伝統工芸品名
+- 工芸ジャンル語ではなく、品目・技法の固有名詞を優先抽出する。
+- 例: `薩摩切子`、`有田焼`、`大島紬`（実データ確認後に採用）
+- 「伝統工芸」だけの一般語は採用しない。
+
+## 5. Name Normalization Rules
+- 表記ゆれ統一: 全角/半角、英数字、長音、括弧の揺れを統一。
+- 同一施設の別表記統合: 公式表記を主キーに採用し、別名は `aliases` に保持。
+- 重複管理: `normalized_name + category` を一意キーとする。
+
+## 6. Evidence Policy
+- 各抽出項目には最低1件の `evidence_url` を必須とする。
+- 複数根拠がある場合は配列保持する。
+- 404/403/著者不一致URLは `invalid_sources` に記録し、表示データには採用しない。
+
+## 7. Output Schema (Draft)
+```json
+{
+  "category": "hotel | museum | traditional_craft",
+  "name": "string",
+  "normalized_name": "string",
+  "aliases": ["string"],
+  "area": "string | null",
+  "evidence_urls": ["https://..."],
+  "notes": "string"
+}
+```
+
+## 8. Execution Checklist
+- [ ] 対象URLが allowlist と author scope を満たす
+- [ ] 抽出対象が 3カテゴリのいずれかに該当する
+- [ ] 一般語ではなく固有名詞で抽出できている
+- [ ] 正規化と重複排除を実施した
+- [ ] evidence URL を付与した
+- [ ] 無効URLを invalid_sources に分離した

--- a/docs/08-issue15-source-audit.md
+++ b/docs/08-issue15-source-audit.md
@@ -1,0 +1,44 @@
+# Issue #15 Source Audit Log
+
+## Purpose
+- 本ドキュメントは Issue #15 の採用前確認ログを残すためのもの。
+- URLの生存確認、本人記事確認、抽出候補、採用判断を分けて管理する。
+- 採用判定が終わるまで、Works本番表示データには反映しない。
+
+## Temporary Audit Page
+- Route: `#/issue15-audit`
+- Data source: `data/issue15SourceCandidates.ts`
+- Page component: `components/Issue15AuditPage.tsx`
+
+## Check Run Order
+1. URL生存確認
+2. 本人記事確認
+3. 抽出候補作成
+4. 正規化・重複排除
+5. 採用 / 保留 / 除外の判定
+
+## Status Policy
+- `unchecked`: まだ確認していない。
+- `valid`: URLが現在も有効。
+- `redirected`: リダイレクト先確認が必要。
+- `blocked`: 403、会員制、bot対策などで通常確認できない。
+- `invalid`: 404、削除、明確な無効URL。
+- `needs_manual_check`: 自動・軽量確認だけでは判断できない。
+
+## Author Policy
+- `confirmed`: 本人記事、著者ページ、本人掲載として確認できた。
+- `unclear`: 本人との紐づきが弱い、または確認材料が不足している。
+- `not_author`: 本人記事ではないと判断した。
+
+## Decision Policy
+- `approved`: 本番表示データへ入れてよい。
+- `keep_candidate`: 候補として保持し、次チェックへ進める。
+- `hold`: 判断保留。追加確認が必要。
+- `exclude`: 表示データには採用しない。
+- `unreviewed`: まだ判定していない。
+
+## Current Starter State
+- 候補URLを `data/issue15SourceCandidates.ts` に登録済み。
+- すべて未確認状態から開始する。
+- 次の作業は URL生存確認のみ。本人記事確認や抽出・採用判定にはまだ進まない。
+

--- a/docs/08-issue15-source-audit.md
+++ b/docs/08-issue15-source-audit.md
@@ -9,6 +9,7 @@
 - Route: `#/issue15-audit`
 - Data source: `data/issue15SourceCandidates.ts`
 - Page component: `components/Issue15AuditPage.tsx`
+- Edited audit state is saved in browser `localStorage` under `issue15-source-audit-state-v1`.
 
 ## Check Run Order
 1. URL生存確認
@@ -41,4 +42,5 @@
 - 候補URLを `data/issue15SourceCandidates.ts` に登録済み。
 - すべて未確認状態から開始する。
 - 次の作業は URL生存確認のみ。本人記事確認や抽出・採用判定にはまだ進まない。
-
+- 確認ページ上で URL / AUTHOR / EXTRACTION / DECISION / CHECKED AT / MEMO を変更できる。
+- 画面上の変更はブラウザ内に保存されるため、正式反映時は内容をデータファイルへ転記する。

--- a/docs/08-issue15-source-audit.md
+++ b/docs/08-issue15-source-audit.md
@@ -10,6 +10,7 @@
 - Data source: `data/issue15SourceCandidates.ts`
 - Page component: `components/Issue15AuditPage.tsx`
 - Edited audit state is saved in browser `localStorage` under `issue15-source-audit-state-v1`.
+- The audit page can export/import the current state as JSON.
 
 ## Check Run Order
 1. URL生存確認
@@ -44,3 +45,4 @@
 - 次の作業は URL生存確認のみ。本人記事確認や抽出・採用判定にはまだ進まない。
 - 確認ページ上で URL / AUTHOR / EXTRACTION / DECISION / CHECKED AT / MEMO を変更できる。
 - 画面上の変更はブラウザ内に保存されるため、正式反映時は内容をデータファイルへ転記する。
+- `JSONをコピー` または `JSONを保存` で確認結果を取り出し、次回作業時は `JSONを取り込む` で復元できる。


### PR DESCRIPTION
## Summary
- add a hidden #/issue15-audit page for pre-adoption source checks
- add structured Issue #15 source candidate data with URL, author, extraction, and decision statuses
- document collection rules and audit status policy

## Validation
- npm run build
- HTTP 200 from http://127.0.0.1:5173/#/issue15-audit

## Notes
- This PR is stacked on refactor/simplify-works-page to avoid mixing with PR #19.
- All candidates intentionally start unchecked; no production Works data is changed.