### PR TITLE
refactor extract works data into data/works.ts (#24)

### DIFF
--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -1,40 +1,14 @@
 import React from 'react';
 import { ArrowUpRight, BookOpenText, Headphones, Landmark, Mail, Newspaper, Sparkles } from 'lucide-react';
+import { WorksLinkItem } from '../types';
+import {
+  achievementLinkCategories,
+  featuredWorks,
+  worksDetailItems,
+  worksMetrics,
+} from '../data/works';
 
-type DetailItem = {
-  title: string;
-  category: string;
-  overview: string;
-  tone: string;
-};
-
-type LinkItem = {
-  title: string;
-  url: string;
-  cta?: 'Visit' | 'Read' | 'Listen' | 'Follow';
-};
-
-type LinkCategory = {
-  name: string;
-  lead: string;
-  slug: string;
-  items: LinkItem[];
-};
-
-type FeaturedWork = {
-  title: string;
-  label: string;
-  summary: string;
-  url: string;
-};
-
-type Metric = {
-  value: string;
-  label: string;
-  note: string;
-};
-
-const getCta = (item: LinkItem): LinkItem['cta'] => {
+const getCta = (item: WorksLinkItem): WorksLinkItem['cta'] => {
   if (item.cta) {
     return item.cta;
   }
@@ -57,151 +31,6 @@ const getDomainLabel = (url: string): string => {
     return '';
   }
 };
-
-const metrics: Metric[] = [
-  {
-    value: '300+',
-    label: 'Articles',
-    note: '美容、旅、暮らし、文化を横断する記事制作',
-  },
-  {
-    value: '5',
-    label: 'Fields',
-    note: 'Beauty / Travel / Editorial / Audio / Interview',
-  },
-  {
-    value: '1',
-    label: 'Sensory Lens',
-    note: '五感で体験を読み解き、伝わる言葉へ整える視点',
-  },
-];
-
-const featuredWorks: FeaturedWork[] = [
-  {
-    title: '美的.com ウェルネス旅企画',
-    label: 'Beauty Trip',
-    summary: '美容視点で旅の体験価値を編み直し、読者が行動に移しやすい導線へ。',
-    url: 'https://www.biteki.com/life-style/others/1661397',
-  },
-  {
-    title: 'りかたんの五感美容旅',
-    label: 'Travel Journal',
-    summary: '土地の空気、食、香り、肌感覚を拾い上げる旅ブログのアーカイブ。',
-    url: 'https://www.tour.ne.jp/blog/rikatan/',
-  },
-  {
-    title: 'Voicy 美容健康アーカイブ',
-    label: 'Audio',
-    summary: '日々のセルフケアを、声でやわらかく届ける継続配信。',
-    url: 'https://voicy.jp/channel/1073/227019',
-  },
-];
-
-const detailItems: DetailItem[] = [
-  {
-    title: '美容・ライフスタイル系メディア掲載',
-    category: 'Beauty Media',
-    overview: '美的、anan Beauty＋、CREA、Hanakoなどで、美容・ライフスタイルを軸にした体験型コンテンツを継続発信。',
-    tone: '体験を読者の暮らしへ接続する、やわらかな実用性。',
-  },
-  {
-    title: '新聞・雑誌・女性向け媒体での連載/寄稿',
-    category: 'Editorial',
-    overview: '日経x woman、シティリビングなどで、日常と美意識を結ぶテーマの記事を掲載。',
-    tone: '媒体トーンを尊重しながら、生活者の視点で整理。',
-  },
-  {
-    title: '旅行・ブログ領域の発信',
-    category: 'Travel Blog',
-    overview: 'トラベルコ「りかたんの五感美容旅」や著者ページを通じて、旅と美容を横断したコンテンツを発信。',
-    tone: '土地の魅力を五感で拾い、読み物として残す視点。',
-  },
-  {
-    title: '音声メディアでの継続配信',
-    category: 'Audio',
-    overview: 'Voicyで美容健康を軸に、習慣・栄養・睡眠・セルフケアなど幅広いテーマを継続発信。',
-    tone: '短く聞けて、今日の行動に移しやすい健康美容の話題。',
-  },
-  {
-    title: 'インタビュー・外部掲載',
-    category: 'Interview',
-    overview: '伝統工芸、ヤマハ音楽教室アンバサダーなど、外部サイトでのインタビュー・掲載実績。',
-    tone: '文化や活動背景を、第三者媒体の文脈で届ける実績。',
-  },
-];
-
-const achievementLinkCategories: LinkCategory[] = [
-  {
-    name: '美容/ライフ',
-    lead: '美容、ウェルネス旅、体験レポートを中心にした掲載先です。',
-    slug: 'beauty-life',
-    items: [
-      { title: '美的', url: 'https://www.biteki.com/' },
-      { title: 'GWや夏休みはどう過ごす？ 心も体もイキイキと過ごせる1泊2日のウェルネスプランを美容賢者が提案 | 美的.com', url: 'https://www.biteki.com/life-style/others/1661397' },
-      { title: '〖GW1泊2日の美トリップ〗美肌整う鹿児島県・霧島の温泉旅｜天然の“泥パック”で全身すべすべに♪ | 美的.com', url: 'https://www.biteki.com/life-style/others/1660535' },
-      { title: '〖14のおすすめ〗ネイルオイル、人気で優秀なヤツ集めました！ | 美的.com', url: 'https://www.biteki.com/nail/nail-howto/292503' },
-      { title: 'anan Beauty ＋', url: 'https://plus.ananweb.jp/' },
-      { title: 'CREAアンバサダー', url: 'https://crea.bunshun.jp/list/author/64993f21b576224852000012' },
-      { title: 'ハナコラボJOURNAL | Hanako Web', url: 'https://hanako.tokyo/tags/hanako-lab-journal/' },
-      { title: '米肌 beauty channel', url: 'https://www.instagram.com/' },
-    ],
-  },
-  {
-    name: '新聞/雑誌',
-    lead: '女性向け媒体を中心に、アンバサダー・連載・記事掲載の導線をまとめています。',
-    slug: 'editorial',
-    items: [
-      { title: '日経x womanアンバサダー', url: 'https://woman.nikkei.com/' },
-      { title: '書き残すことで気持ちがスッキリする手帳活用術［PR］（2ページ目）：日経xwoman', url: 'https://woman.nikkei.com/atcl/cons/051300011/101300034/?P=2' },
-      { title: '突然の予定変更もOK！卓上カレンダーの活用法とは〖日経WOMAN16年6月号〗：日経xwoman', url: 'https://woman.nikkei.com/atcl/doors/wol/magazine/15/113000009/042000022/' },
-      { title: '日常に五感のスイッチを｜シティリビングWeb', url: 'https://city.living.jp/citymate/citymate415/' },
-      { title: 'シティリビング横浜版', url: 'https://book.living.jp/ebooks/cityliving/yokohama/20190208/index_h5.html' },
-    ],
-  },
-  {
-    name: '旅ブログ',
-    lead: '旅と感性をテーマにしたブログ・著者ページのアーカイブです。',
-    slug: 'travel-blog',
-    items: [
-      { title: 'りかたんの五感美容旅 | トラベルコ', url: 'https://www.tour.ne.jp/blog/rikatan/' },
-      { title: '楽活', url: 'https://rakukatsu.jp/author/takahashi-rika' },
-    ],
-  },
-  {
-    name: 'Voicy',
-    lead: 'Voicyでの美容健康コンテンツを中心に、継続発信のアーカイブをまとめています。',
-    slug: 'voicy',
-    items: [
-      { title: 'Voicy 〖美容健康〗アートの力で心身共にキレイで健康に！', url: 'https://voicy.jp/channel/1073/227019' },
-      { title: 'Voicy 〖美容健康〗二の腕と猫背に効くエクササイズとは？', url: 'https://voicy.jp/channel/1073/223984' },
-      { title: 'Voicy 〖美容健康〗まずはお口から！大病防ぐオーラルケア', url: 'https://voicy.jp/channel/1073/220292' },
-      { title: 'Voicy 〖美容健康〗りんご酢の取り入れ方について', url: 'https://voicy.jp/channel/1073/218281' },
-      { title: 'Voicy 〖美容健康〗意外と知らない！？日本茶の魅力について', url: 'https://voicy.jp/channel/1073/214884' },
-      { title: 'Voicy 〖美容健康〗人気読者モデルオススメ美容法とは？', url: 'https://voicy.jp/channel/1073/198824' },
-      { title: 'Voicy 〖美容健康〗健康美容の味方！マヌカハニーについて', url: 'https://voicy.jp/channel/1073/200159' },
-      { title: 'Voicy 〖美容健康〗うま味の秘密を知る！かつお節の魅力', url: 'https://voicy.jp/channel/1073/198829' },
-      { title: 'Voicy 〖美容健康〗もっと大切にしたい！睡眠の改善法', url: 'https://voicy.jp/channel/1073/194995' },
-      { title: 'Voicy 〖美容健康〗早期発見に必要ながん検診について', url: 'https://voicy.jp/channel/1073/192909' },
-      { title: 'Voicy 〖美容健康〗美と健康に欠かせない味噌の魅力とは？', url: 'https://voicy.jp/channel/1073/191567' },
-      { title: 'Voicy 〖美容健康〗歯周病も口臭もあいうべ体操で予防！？', url: 'https://voicy.jp/channel/1073/188336' },
-      { title: 'Voicy 〖美容健康〗毎日1分！身体が軽くなる習慣', url: 'https://voicy.jp/channel/1073/171131' },
-      { title: 'Voicy 〖美容健康〗胃カメラの受け方と胃の健康を守る方法', url: 'https://voicy.jp/channel/1073/178254' },
-      { title: 'Voicy 〖美容健康〗香りの活用法で人生が豊かになる方法', url: 'https://voicy.jp/channel/1073/179146' },
-      { title: 'Voicy 〖美容健康〗好感度UP！自分に似合う色の見つけ方', url: 'https://voicy.jp/channel/1073/172049' },
-      { title: 'Voicy 〖美容健康〗見た目の印象を変える髪のお手入れ方法', url: 'https://voicy.jp/channel/1073/167200' },
-      { title: 'Voicy 〖美容健康〗呼吸法で不安を瞬間リフレッシュ！', url: 'https://voicy.jp/channel/1073/170892' },
-    ],
-  },
-  {
-    name: 'その他',
-    lead: '外部サイトでのインタビュー掲載・アンバサダー掲載です。',
-    slug: 'other',
-    items: [
-      { title: '伝統工芸インタビュー', url: 'https://girlsartalk.com/column/16874.html' },
-      { title: 'ヤマハ音楽教室アンバサダーインタビュー', url: 'https://www.yamaha-ongaku.com/music-school/why_yamaha/ambassador/article08.html' },
-    ],
-  },
-];
 
 const categoryIcons = [BookOpenText, Newspaper, Landmark, Headphones, Sparkles];
 
@@ -254,7 +83,7 @@ const WorksPage: React.FC = () => {
             </div>
 
             <div className="relative z-10 grid grid-cols-1 gap-3">
-              {metrics.map((metric) => (
+              {worksMetrics.map((metric) => (
                 <div key={metric.label} className="border border-stone-200 bg-stone-50/90 p-5 backdrop-blur">
                   <span className="block font-serif text-4xl text-earth-gold">{metric.value}</span>
                   <span className="mt-2 block text-xs uppercase tracking-widest text-stone-500">{metric.label}</span>
@@ -311,7 +140,7 @@ const WorksPage: React.FC = () => {
             </div>
 
             <div className="grid grid-cols-1 gap-px overflow-hidden border border-stone-200 bg-stone-200 md:grid-cols-2 lg:grid-cols-5">
-              {detailItems.map((item, index) => {
+              {worksDetailItems.map((item, index) => {
                 const Icon = categoryIcons[index] ?? Sparkles;
                 return (
                   <article key={item.title} className="bg-stone-50 p-5 md:p-6">

--- a/data/works.ts
+++ b/data/works.ts
@@ -1,0 +1,151 @@
+import {
+  FeaturedWork,
+  WorksDetailItem,
+  WorksLinkCategory,
+  WorksMetric,
+} from '../types';
+
+export const worksMetrics: WorksMetric[] = [
+  {
+    value: '300+',
+    label: 'Articles',
+    note: '美容、旅、暮らし、文化を横断する記事制作',
+  },
+  {
+    value: '5',
+    label: 'Fields',
+    note: 'Beauty / Travel / Editorial / Audio / Interview',
+  },
+  {
+    value: '1',
+    label: 'Sensory Lens',
+    note: '五感で体験を読み解き、伝わる言葉へ整える視点',
+  },
+];
+
+export const featuredWorks: FeaturedWork[] = [
+  {
+    title: '美的.com ウェルネス旅企画',
+    label: 'Beauty Trip',
+    summary: '美容視点で旅の体験価値を編み直し、読者が行動に移しやすい導線へ。',
+    url: 'https://www.biteki.com/life-style/others/1661397',
+  },
+  {
+    title: 'りかたんの五感美容旅',
+    label: 'Travel Journal',
+    summary: '土地の空気、食、香り、肌感覚を拾い上げる旅ブログのアーカイブ。',
+    url: 'https://www.tour.ne.jp/blog/rikatan/',
+  },
+  {
+    title: 'Voicy 美容健康アーカイブ',
+    label: 'Audio',
+    summary: '日々のセルフケアを、声でやわらかく届ける継続配信。',
+    url: 'https://voicy.jp/channel/1073/227019',
+  },
+];
+
+export const worksDetailItems: WorksDetailItem[] = [
+  {
+    title: '美容・ライフスタイル系メディア掲載',
+    category: 'Beauty Media',
+    overview: '美的、anan Beauty＋、CREA、Hanakoなどで、美容・ライフスタイルを軸にした体験型コンテンツを継続発信。',
+    tone: '体験を読者の暮らしへ接続する、やわらかな実用性。',
+  },
+  {
+    title: '新聞・雑誌・女性向け媒体での連載/寄稿',
+    category: 'Editorial',
+    overview: '日経x woman、シティリビングなどで、日常と美意識を結ぶテーマの記事を掲載。',
+    tone: '媒体トーンを尊重しながら、生活者の視点で整理。',
+  },
+  {
+    title: '旅行・ブログ領域の発信',
+    category: 'Travel Blog',
+    overview: 'トラベルコ「りかたんの五感美容旅」や著者ページを通じて、旅と美容を横断したコンテンツを発信。',
+    tone: '土地の魅力を五感で拾い、読み物として残す視点。',
+  },
+  {
+    title: '音声メディアでの継続配信',
+    category: 'Audio',
+    overview: 'Voicyで美容健康を軸に、習慣・栄養・睡眠・セルフケアなど幅広いテーマを継続発信。',
+    tone: '短く聞けて、今日の行動に移しやすい健康美容の話題。',
+  },
+  {
+    title: 'インタビュー・外部掲載',
+    category: 'Interview',
+    overview: '伝統工芸、ヤマハ音楽教室アンバサダーなど、外部サイトでのインタビュー・掲載実績。',
+    tone: '文化や活動背景を、第三者媒体の文脈で届ける実績。',
+  },
+];
+
+export const achievementLinkCategories: WorksLinkCategory[] = [
+  {
+    name: '美容/ライフ',
+    lead: '美容、ウェルネス旅、体験レポートを中心にした掲載先です。',
+    slug: 'beauty-life',
+    items: [
+      { title: '美的', url: 'https://www.biteki.com/' },
+      { title: 'GWや夏休みはどう過ごす？ 心も体もイキイキと過ごせる1泊2日のウェルネスプランを美容賢者が提案 | 美的.com', url: 'https://www.biteki.com/life-style/others/1661397' },
+      { title: '〖GW1泊2日の美トリップ〗美肌整う鹿児島県・霧島の温泉旅｜天然の“泥パック”で全身すべすべに♪ | 美的.com', url: 'https://www.biteki.com/life-style/others/1660535' },
+      { title: '〖14のおすすめ〗ネイルオイル、人気で優秀なヤツ集めました！ | 美的.com', url: 'https://www.biteki.com/nail/nail-howto/292503' },
+      { title: 'anan Beauty ＋', url: 'https://plus.ananweb.jp/' },
+      { title: 'CREAアンバサダー', url: 'https://crea.bunshun.jp/list/author/64993f21b576224852000012' },
+      { title: 'ハナコラボJOURNAL | Hanako Web', url: 'https://hanako.tokyo/tags/hanako-lab-journal/' },
+      { title: '米肌 beauty channel', url: 'https://www.instagram.com/' },
+    ],
+  },
+  {
+    name: '新聞/雑誌',
+    lead: '女性向け媒体を中心に、アンバサダー・連載・記事掲載の導線をまとめています。',
+    slug: 'editorial',
+    items: [
+      { title: '日経x womanアンバサダー', url: 'https://woman.nikkei.com/' },
+      { title: '書き残すことで気持ちがスッキリする手帳活用術［PR］（2ページ目）：日経xwoman', url: 'https://woman.nikkei.com/atcl/cons/051300011/101300034/?P=2' },
+      { title: '突然の予定変更もOK！卓上カレンダーの活用法とは〖日経WOMAN16年6月号〗：日経xwoman', url: 'https://woman.nikkei.com/atcl/doors/wol/magazine/15/113000009/042000022/' },
+      { title: '日常に五感のスイッチを｜シティリビングWeb', url: 'https://city.living.jp/citymate/citymate415/' },
+      { title: 'シティリビング横浜版', url: 'https://book.living.jp/ebooks/cityliving/yokohama/20190208/index_h5.html' },
+    ],
+  },
+  {
+    name: '旅ブログ',
+    lead: '旅と感性をテーマにしたブログ・著者ページのアーカイブです。',
+    slug: 'travel-blog',
+    items: [
+      { title: 'りかたんの五感美容旅 | トラベルコ', url: 'https://www.tour.ne.jp/blog/rikatan/' },
+      { title: '楽活', url: 'https://rakukatsu.jp/author/takahashi-rika' },
+    ],
+  },
+  {
+    name: 'Voicy',
+    lead: 'Voicyでの美容健康コンテンツを中心に、継続発信のアーカイブをまとめています。',
+    slug: 'voicy',
+    items: [
+      { title: 'Voicy 〖美容健康〗アートの力で心身共にキレイで健康に！', url: 'https://voicy.jp/channel/1073/227019' },
+      { title: 'Voicy 〖美容健康〗二の腕と猫背に効くエクササイズとは？', url: 'https://voicy.jp/channel/1073/223984' },
+      { title: 'Voicy 〖美容健康〗まずはお口から！大病防ぐオーラルケア', url: 'https://voicy.jp/channel/1073/220292' },
+      { title: 'Voicy 〖美容健康〗りんご酢の取り入れ方について', url: 'https://voicy.jp/channel/1073/218281' },
+      { title: 'Voicy 〖美容健康〗意外と知らない！？日本茶の魅力について', url: 'https://voicy.jp/channel/1073/214884' },
+      { title: 'Voicy 〖美容健康〗人気読者モデルオススメ美容法とは？', url: 'https://voicy.jp/channel/1073/198824' },
+      { title: 'Voicy 〖美容健康〗健康美容の味方！マヌカハニーについて', url: 'https://voicy.jp/channel/1073/200159' },
+      { title: 'Voicy 〖美容健康〗うま味の秘密を知る！かつお節の魅力', url: 'https://voicy.jp/channel/1073/198829' },
+      { title: 'Voicy 〖美容健康〗もっと大切にしたい！睡眠の改善法', url: 'https://voicy.jp/channel/1073/194995' },
+      { title: 'Voicy 〖美容健康〗早期発見に必要ながん検診について', url: 'https://voicy.jp/channel/1073/192909' },
+      { title: 'Voicy 〖美容健康〗美と健康に欠かせない味噌の魅力とは？', url: 'https://voicy.jp/channel/1073/191567' },
+      { title: 'Voicy 〖美容健康〗歯周病も口臭もあいうべ体操で予防！？', url: 'https://voicy.jp/channel/1073/188336' },
+      { title: 'Voicy 〖美容健康〗毎日1分！身体が軽くなる習慣', url: 'https://voicy.jp/channel/1073/171131' },
+      { title: 'Voicy 〖美容健康〗胃カメラの受け方と胃の健康を守る方法', url: 'https://voicy.jp/channel/1073/178254' },
+      { title: 'Voicy 〖美容健康〗香りの活用法で人生が豊かになる方法', url: 'https://voicy.jp/channel/1073/179146' },
+      { title: 'Voicy 〖美容健康〗好感度UP！自分に似合う色の見つけ方', url: 'https://voicy.jp/channel/1073/172049' },
+      { title: 'Voicy 〖美容健康〗見た目の印象を変える髪のお手入れ方法', url: 'https://voicy.jp/channel/1073/167200' },
+      { title: 'Voicy 〖美容健康〗呼吸法で不安を瞬間リフレッシュ！', url: 'https://voicy.jp/channel/1073/170892' },
+    ],
+  },
+  {
+    name: 'その他',
+    lead: '外部サイトでのインタビュー掲載・アンバサダー掲載です。',
+    slug: 'other',
+    items: [
+      { title: '伝統工芸インタビュー', url: 'https://girlsartalk.com/column/16874.html' },
+      { title: 'ヤマハ音楽教室アンバサダーインタビュー', url: 'https://www.yamaha-ongaku.com/music-school/why_yamaha/ambassador/article08.html' },
+    ],
+  },
+];

--- a/types.ts
+++ b/types.ts
@@ -12,3 +12,36 @@ export interface NavItem {
   label: string;
   href: string;
 }
+
+export interface WorksMetric {
+  value: string;
+  label: string;
+  note: string;
+}
+
+export interface FeaturedWork {
+  title: string;
+  label: string;
+  summary: string;
+  url: string;
+}
+
+export interface WorksDetailItem {
+  title: string;
+  category: string;
+  overview: string;
+  tone: string;
+}
+
+export interface WorksLinkItem {
+  title: string;
+  url: string;
+  cta?: 'Visit' | 'Read' | 'Listen' | 'Follow';
+}
+
+export interface WorksLinkCategory {
+  name: string;
+  lead: string;
+  slug: string;
+  items: WorksLinkItem[];
+}


### PR DESCRIPTION
Closes #24

## Summary
- 静的データ（\`worksMetrics\`, \`featuredWorks\`, \`worksDetailItems\`, \`achievementLinkCategories\`）を \`components/WorksPage.tsx\` から \`data/works.ts\` に分離。
- 型は \`types.ts\` に移動（\`WorksMetric\`, \`FeaturedWork\`, \`WorksDetailItem\`, \`WorksLinkItem\`, \`WorksLinkCategory\`）。
- \`WorksPage.tsx\` は import するだけに簡略化（412 → 219 行）。
- \`getCta\` / \`getDomainLabel\` ヘルパーは表示ロジックと密結合のためファイル内に保持（issue 上は「検討」事項）。

## Why
後続 issue（#27 メタ情報追加 / #29 Featured Editorial 化）でデータ構造を拡張するための前提整備。

## Test plan
- [x] \`npx tsc --noEmit\` 型チェック通過
- [x] \`npm run build\` 成功
- [ ] preview デプロイで Works ページの表示が変わっていないことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)