### PR TITLE
feat redesign featured works as editorial cards (#29)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(git add *)",
-      "Bash(git commit -m ' *)",
-      "Bash(git push *)"
-    ]
-  }
-}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git add *)",
+      "Bash(git commit -m ' *)",
+      "Bash(git push *)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code local settings
+.claude/

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -105,27 +105,55 @@ const WorksPage: React.FC = () => {
             <span className="text-xs uppercase tracking-widest text-stone-500">{featuredWorks.length} Highlights</span>
           </div>
 
-          <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
-            {featuredWorks.map((work, index) => (
-              <a
-                key={work.title}
-                href={work.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="group min-h-[260px] border border-stone-200 bg-stone-100 p-6 transition-colors hover:border-earth-terra/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
-              >
-                <div className="flex items-start justify-between gap-4">
-                  <span className="text-xs uppercase tracking-widest text-earth-terra">{work.label}</span>
-                  <span className="font-serif text-3xl text-stone-300">0{index + 1}</span>
-                </div>
-                <h4 className="mt-14 font-serif text-2xl leading-relaxed text-stone-900">{work.title}</h4>
-                <p className="mt-4 text-sm leading-loose text-stone-600">{work.summary}</p>
-                <span className="mt-6 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-stone-500 transition-colors group-hover:text-earth-terra">
-                  View
-                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
-                </span>
-              </a>
-            ))}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            {featuredWorks.map((work, index) => {
+              const meta = [work.year ? String(work.year) : null, work.mediaName ?? null].filter(Boolean) as string[];
+              return (
+                <a
+                  key={work.title}
+                  href={work.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="group flex flex-col overflow-hidden border border-stone-200 bg-stone-50 transition-colors hover:border-earth-terra/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                >
+                  <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-stone-100 via-stone-200 to-stone-300">
+                    {work.keyVisual ? (
+                      <img
+                        src={work.keyVisual}
+                        alt=""
+                        className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
+                        loading={index === 0 ? 'eager' : 'lazy'}
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <span aria-hidden="true" className="select-none font-serif text-[8rem] leading-none text-stone-400/60 transition-transform duration-700 ease-out group-hover:scale-105">
+                          0{index + 1}
+                        </span>
+                      </div>
+                    )}
+                    <span className="absolute left-4 top-4 inline-flex items-center bg-stone-900/85 px-3 py-1 text-[11px] uppercase tracking-widest text-stone-50 backdrop-blur">
+                      {work.label}
+                    </span>
+                  </div>
+                  <div className="flex flex-1 flex-col p-6">
+                    {meta.length > 0 && (
+                      <span className="text-[11px] uppercase tracking-widest text-stone-500">{meta.join(' · ')}</span>
+                    )}
+                    <h4 className="mt-3 font-serif text-2xl leading-relaxed text-stone-900">{work.title}</h4>
+                    <p className="mt-4 text-sm leading-loose text-stone-600">{work.summary}</p>
+                    {work.quote && (
+                      <blockquote className="mt-5 border-l-2 border-earth-terra pl-4 font-serif text-sm italic leading-loose text-earth-sage">
+                        “{work.quote}”
+                      </blockquote>
+                    )}
+                    <span className="mt-auto pt-6 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-stone-500 transition-colors group-hover:text-earth-terra">
+                      View
+                      <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+                    </span>
+                  </div>
+                </a>
+              );
+            })}
           </div>
         </section>
 

--- a/data/works.ts
+++ b/data/works.ts
@@ -29,18 +29,24 @@ export const featuredWorks: FeaturedWork[] = [
     label: 'Beauty Trip',
     summary: '美容視点で旅の体験価値を編み直し、読者が行動に移しやすい導線へ。',
     url: 'https://www.biteki.com/life-style/others/1661397',
+    mediaName: '美的.com',
+    quote: '泊まる、食べる、巡る。すべてを美容のレンズで読み解く。',
   },
   {
     title: 'りかたんの五感美容旅',
     label: 'Travel Journal',
     summary: '土地の空気、食、香り、肌感覚を拾い上げる旅ブログのアーカイブ。',
     url: 'https://www.tour.ne.jp/blog/rikatan/',
+    mediaName: 'トラベルコ',
+    quote: '旅は感覚の記録。情報ではなく体温を残す。',
   },
   {
     title: 'Voicy 美容健康アーカイブ',
     label: 'Audio',
     summary: '日々のセルフケアを、声でやわらかく届ける継続配信。',
     url: 'https://voicy.jp/channel/1073/227019',
+    mediaName: 'Voicy 美容健康',
+    quote: '読むのが疲れる日も、声なら届く。',
   },
 ];
 

--- a/types.ts
+++ b/types.ts
@@ -24,6 +24,10 @@ export interface FeaturedWork {
   label: string;
   summary: string;
   url: string;
+  mediaName?: string;
+  year?: number;
+  quote?: string;
+  keyVisual?: string;
 }
 
 export interface WorksDetailItem {


### PR DESCRIPTION
Closes #29

## Summary
Featured Works を「テキスト + 連番」から、4:5 のキービジュアルを中心とした Editor's Pick 形式に再設計。

### Changes
- \`FeaturedWork\` 型に \`mediaName\` / \`year\` / \`quote\` / \`keyVisual\` を追加（任意）
- 各 Featured に \`mediaName\` と \`quote\` を埋め込み
- カード構造を再設計
  - 上段: 4:5 アスペクトのキービジュアル領域（画像未指定時は stone グラデーション + 大型 serif 連番にフォールバック）
  - 左上に媒体ラベルチップ（dark/blur で被覆）
  - hover で画像/連番が微拡大（design guide §5 / §7）
  - 下段: meta 行 → タイトル → サマリ → 引用 blockquote → View ラベル
- 1 枚目だけ \`loading="eager"\` を付与（LCP 寄与、後続 #32 で fetchpriority と合わせて整える）

### Notes
- \`keyVisual\` の本番画像は未配置。フォールバックの状態で merge する想定（issue 受け入れ条件「画像が用意できないときのフォールバック」を満たす）
- 画像最適化と alt の本格対応は #32 で実施

## Bonus
- \`.claude/settings.json\` を誤ってトラックしてしまっていたため、削除 + \`.gitignore\` に \`.claude/\` を追加

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で 3 枚の Featured が縦長カードで描画されること
- [ ] preview で hover 時にビジュアル領域が微拡大すること
- [ ] スマホで blockquote が画面幅に収まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)