### PR TITLE
feat add editors note section to works page (#30)

### DIFF
--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -160,6 +160,22 @@ const WorksPage: React.FC = () => {
           </div>
         </section>
 
+        <section aria-label="Editor's Note" className="border-b border-stone-200 bg-stone-100/70">
+          <div className="mx-auto max-w-screen-md px-6 py-14 text-center md:py-20">
+            <span className="block text-[11px] uppercase tracking-[0.3em] text-earth-sage">Editor's Note</span>
+            <p className="mt-6 font-serif text-xl leading-loose text-stone-800 md:text-3xl">
+              数値ではなく、
+              <br className="md:hidden" />
+              五感で読み解いた体験を編集する。
+            </p>
+            <p className="mt-6 text-sm leading-loose text-stone-500 md:text-base">
+              媒体ごとの空気を読み、生活者の感覚に翻訳する。
+              <br className="hidden md:block" />
+              静かに伝わる文章を選び続けてきました。
+            </p>
+          </div>
+        </section>
+
         <section id="featured-works" className="mx-auto max-w-screen-xl px-6 py-16 md:py-20">
           <div className="mb-8 grid grid-cols-1 gap-6 border-b border-stone-200 pb-5 md:grid-cols-[1fr_auto] md:items-end">
             <div>


### PR DESCRIPTION
Closes #30

## Summary
Hero と Featured の間に \`Editor's Note\` セクションを追加し、視覚リズムとプロフィール文脈を補強。

- bg: \`stone-100/70\` で前後（gradient hero / 白の Featured）と差を作り、視覚の "息継ぎ" を生む
- 中央寄せ、最大幅 \`screen-md\`、serif の大型ステートメント
- メインステートメント: 「数値ではなく、五感で読み解いた体験を編集する。」
- 補足リード: 媒体トーンを尊重しながら生活者の視点に翻訳する執筆スタンス
- Home の \`#about\` Profile セクションとは別の編集視点で書く（重複回避）

## Notes
- 既存の Expertise (bg-stone-100/70) と同色だが、間に Featured (stone-50) が挟まるため、100→50→100 のリズムになる

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Hero → Editor's Note → Featured の順に視覚段差ができていること
- [ ] スマホでステートメントの改行位置が読みやすいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)