### PR TITLE
chore codify image loading attributes (#32)

### DIFF
--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -209,6 +209,8 @@ const WorksPage: React.FC = () => {
                         alt=""
                         className="h-full w-full object-cover transition-transform duration-700 ease-out group-hover:scale-105"
                         loading={index === 0 ? 'eager' : 'lazy'}
+                        decoding={index === 0 ? 'sync' : 'async'}
+                        {...(index === 0 ? { fetchpriority: 'high' as const } : {})}
                       />
                     ) : (
                       <div className="absolute inset-0 flex items-center justify-center">

--- a/docs/02-design-guide.md
+++ b/docs/02-design-guide.md
@@ -64,9 +64,14 @@ Accessibility notes:
   - Latest: `3:2`
   - Profile: `3:4`
 - Compression policy:
-  - 本番はWebP/AVIF優先、LCP画像は優先最適化
+  - 本番は WebP/AVIF 優先、LCP 画像は優先最適化
+  - 配信は `<picture>` で AVIF → WebP → JPEG/PNG のフォールバック順で並べる
+- Loading attributes:
+  - LCP 候補（Hero / Featured 1 枚目）: `loading="eager"` + `decoding="sync"` + `fetchpriority="high"`
+  - それ以外: `loading="lazy"` + `decoding="async"`
 - Alt text policy:
   - 装飾以外は意味のある代替テキストを付与
+  - 装飾画像は `alt=""` + `aria-hidden="true"` を併用
 
 ## 7. Motion
 - Transition style: `fade-in-up` + gentle hover transitions


### PR DESCRIPTION
Closes #32

## Summary
WorksPage に実画像がほぼ無い現状（Hero はタイポ + Featured はフォールバック）の中で、将来 \`keyVisual\` に画像が入ったときに LCP 最適化が即効くよう、属性ポリシーをコードと docs に固定化。

### Code
- Featured \`<img>\` 1 枚目: \`loading="eager"\` + \`decoding="sync"\` + \`fetchpriority="high"\`
- それ以外: \`loading="lazy"\` + \`decoding="async"\`
- \`fetchpriority\` は React 型未対応の可能性があるため spread で渡す（実 DOM 属性として通る）

### Docs
- \`docs/02-design-guide.md\` §6 に loading attributes セクションを追加
  - LCP 候補と通常画像の属性使い分けを明文化
  - \`<picture>\` フォールバック順（AVIF → WebP → JPEG/PNG）も記載
  - alt 装飾画像の \`aria-hidden\` 併用を追記

## Notes
- 実 WebP/AVIF 変換は本番素材投入時に実施（vite-plugin-image-presets 等の導入は別 issue 化推奨）
- \`referrerPolicy="no-referrer-when-downgrade"\` は採用見送り。既存の \`rel="noopener noreferrer"\` の方が strict でセキュア（issue 受け入れ条件と矛盾しないと判断）
- Hero / MediaKit で使われている \`hero-snoopy.jpg\` の差し替えは別 issue 候補

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で DevTools の Network タブで Featured 1 枚目（あれば）に \`fetchpriority=high\` が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)