### PR TITLE
chore tentative profile name and featured visuals

### DIFF
--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -25,7 +25,7 @@ const Profile: React.FC = () => {
           
           <div className="space-y-6 text-stone-600 leading-loose font-serif text-sm md:text-base">
             <p>
-              <strong>Profile Name</strong>
+              <strong>ぺんぺんすけ</strong>
               <br />
               アート、旅、美容をテーマに執筆活動を行うライター・エディター。
             </p>

--- a/data/works.ts
+++ b/data/works.ts
@@ -31,6 +31,8 @@ export const featuredWorks: FeaturedWork[] = [
     url: 'https://www.biteki.com/life-style/others/1661397',
     mediaName: '美的.com',
     quote: '泊まる、食べる、巡る。すべてを美容のレンズで読み解く。',
+    // 暫定: 温泉/水辺イメージ。本番素材投入時に差し替え予定
+    keyVisual: 'https://picsum.photos/id/1015/800/1000',
   },
   {
     title: 'りかたんの五感美容旅',
@@ -39,6 +41,8 @@ export const featuredWorks: FeaturedWork[] = [
     url: 'https://www.tour.ne.jp/blog/rikatan/',
     mediaName: 'トラベルコ',
     quote: '旅は感覚の記録。情報ではなく体温を残す。',
+    // 暫定: 風景/旅情イメージ
+    keyVisual: 'https://picsum.photos/id/1018/800/1000',
   },
   {
     title: 'Voicy 美容健康アーカイブ',
@@ -47,6 +51,8 @@ export const featuredWorks: FeaturedWork[] = [
     url: 'https://voicy.jp/channel/1073/227019',
     mediaName: 'Voicy 美容健康',
     quote: '読むのが疲れる日も、声なら届く。',
+    // 暫定: 落ち着いた抽象/光イメージ
+    keyVisual: 'https://picsum.photos/id/96/800/1000',
   },
 ];
 


### PR DESCRIPTION
## Summary
- \`components/Profile.tsx\`: 表示名を 'Profile Name' → 'ぺんぺんすけ' に変更
- \`data/works.ts\`: Featured 3 件に Picsum の暫定 \`keyVisual\` を設定
  - id 1015（風景）→ 美的.com ウェルネス旅
  - id 1018（自然）→ りかたんの五感美容旅
  - id 96（光/抽象）→ Voicy

本番素材検討時の参考用。各アイテムに本番差し替え予定の旨をコメント明記。

## Notes
- ポートレート（Profile セクション）は Picsum id 64 のままユーザー指定により暫定維持
- 連絡先 / SNS URL もユーザー指定により暫定維持

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Featured カードに画像が表示されること
- [ ] preview で Profile に "ぺんぺんすけ" が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)