### PR TITLE
chore point instagram links to rika05181

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -22,7 +22,7 @@ const Contact: React.FC = () => {
             メールで連絡する
           </a>
           <a
-            href="https://example.com/sensoria-instagram"
+            href="https://www.instagram.com/rika05181/"
             target="_blank"
             rel="noopener noreferrer"
             className="px-8 py-3 border border-stone-400 text-stone-700 text-sm tracking-widest hover:border-earth-terra hover:text-earth-terra transition-colors duration-300"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -18,10 +18,10 @@ const Footer: React.FC = () => {
 
         <div className="flex space-x-8 mb-12">
           <a
-            href="https://example.com/sensoria-instagram"
+            href="https://www.instagram.com/rika05181/"
             target="_blank"
             rel="noopener noreferrer"
-            aria-label="Instagram (dummy)"
+            aria-label="Instagram"
             className="text-stone-500 hover:text-white transition-colors"
           >
             <Instagram size={20} />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -45,10 +45,10 @@ const Header: React.FC = () => {
           ))}
           <div className="flex items-center border-l border-stone-300 pl-6">
             <a
-              href="https://www.instagram.com/?hl=ja"
+              href="https://www.instagram.com/rika05181/"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Instagram (dummy)"
+              aria-label="Instagram"
               className="text-stone-500 hover:text-earth-terra transition-colors"
             >
               <Instagram size={18} />
@@ -80,10 +80,10 @@ const Header: React.FC = () => {
           ))}
           <div className="flex justify-center pt-4">
             <a
-              href="https://www.instagram.com/?hl=ja"
+              href="https://www.instagram.com/rika05181/"
               target="_blank"
               rel="noopener noreferrer"
-              aria-label="Instagram (dummy)"
+              aria-label="Instagram"
               onClick={() => setMobileMenuOpen(false)}
             >
               <Instagram className="text-stone-500" />


### PR DESCRIPTION
## Summary
ダミーだった Instagram URL を実アカウント \`rika05181\` に置換。

- \`components/Header.tsx\`: PC ナビ + モバイルメニューの 2 箇所
- \`components/Footer.tsx\`: フッター SNS アイコン
- \`components/Contact.tsx\`: 問い合わせセクションの「Instagramを見る」

aria-label の \`(dummy)\` 注記も削除。

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で各 Instagram リンクが \`https://www.instagram.com/rika05181/\` に飛ぶこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)