### PR TITLE
feat restructure global navigation

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -33,6 +33,17 @@ const App: React.FC = () => {
   }, []);
 
   React.useEffect(() => {
+    if (route === 'home') {
+      const hash = window.location.hash;
+      if (hash && !hash.startsWith('#/')) {
+        const id = hash.slice(1);
+        const el = document.getElementById(id);
+        if (el) {
+          el.scrollIntoView();
+          return;
+        }
+      }
+    }
     window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
   }, [route]);
 

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -12,7 +12,8 @@ const Footer: React.FC = () => {
 
         <nav className="flex flex-wrap justify-center gap-6 md:gap-12 mb-12 text-sm tracking-widest uppercase">
           <a href="#about" className="hover:text-white transition-colors">About</a>
-          <a href="#works" className="hover:text-white transition-colors">Works</a>
+          <a href="#/works" className="hover:text-white transition-colors">Works</a>
+          <a href="#/media-kit" className="hover:text-white transition-colors">Media Kit</a>
           <a href="#contact" className="hover:text-white transition-colors">Contact</a>
         </nav>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,7 +4,8 @@ import { NavItem } from '../types';
 
 const navItems: NavItem[] = [
   { label: 'About', href: '#about' },
-  { label: 'Works', href: '#works' },
+  { label: 'Works', href: '#/works' },
+  { label: 'Media Kit', href: '#/media-kit' },
   { label: 'Contact', href: '#contact' },
 ];
 


### PR DESCRIPTION
## Summary
ナビゲーションがスクロールヘルパー化していた問題（メニューを開いても結局同じページの中をスクロールするだけ）を修正。

### Header / Footer
\`About / Works / Contact\` → \`About / Works / Media Kit / Contact\`
- \`Works\` の遷移先: \`#works\`（Home の summary セクション）→ \`#/works\`（専用ページ）
- \`Media Kit\` を新規追加（これまでは Works ページの中からしか辿れなかった）
- \`About\` / \`Contact\` は引き続き Home 内アンカー

### App routing
- 専用ページ → Home のアンカー（例: \`#/works\` 上で \`About\` をクリック）に遷移したとき、\`scrollTo(0,0)\` が anchor の scrollIntoView を上書きしていた問題を修正
- \`route === 'home'\` かつ hash が \`#/\` で始まらない場合は、対象要素にスクロール

## Notes
- モバイルメニューも自動で同じ navItems を使うため、ハンバーガーから Works / Media Kit に飛べるようになる
- Footer の SNS / Logo 部分は変更なし

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Header の Works → 専用ページに遷移すること
- [ ] preview で 専用ページ上で About をクリック → Home に戻り、About セクションまでスクロールすること
- [ ] preview でモバイルメニューに Media Kit が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)