### PR TITLE
feat overhaul home with editorial chapter layout

### DIFF
--- a/components/Concept.tsx
+++ b/components/Concept.tsx
@@ -2,33 +2,38 @@ import React from 'react';
 
 const Concept: React.FC = () => {
   return (
-    <section id="concept" className="py-24 md:py-32 bg-stone-50 relative">
+    <section id="concept" className="relative bg-stone-900 py-24 md:py-32 text-stone-100">
+      {/* Side rule decoration (large screens) */}
+      <div aria-hidden="true" className="absolute left-8 top-12 hidden text-[10px] uppercase tracking-[0.4em] text-stone-500 md:block">
+        Chapter 01 — Concept
+      </div>
+      <div aria-hidden="true" className="absolute right-8 bottom-12 hidden text-[10px] uppercase tracking-[0.4em] text-stone-500 md:block">
+        Sensoria / Five Senses
+      </div>
+
       <div className="max-w-screen-md mx-auto px-6">
-        <div className="text-center mb-16">
-          <span className="block text-xs tracking-[0.4em] text-stone-400 uppercase mb-4">Introduction</span>
-          <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-widest">五感美容とは</h2>
+        <div className="text-center mb-14">
+          <span className="block text-xs tracking-[0.4em] text-earth-gold uppercase mb-5">Introduction</span>
+          <h2 className="text-3xl md:text-5xl font-medium font-serif text-stone-50 tracking-widest">五感美容とは</h2>
+          <div className="mt-6 mx-auto h-[1px] w-16 bg-earth-gold/60" />
         </div>
 
-        <div className="prose prose-stone prose-lg mx-auto text-stone-600 font-serif leading-loose text-justify md:text-center">
-          <p className="mb-8">
+        <div className="font-serif text-stone-200 leading-loose text-justify md:text-center space-y-8 text-base md:text-lg">
+          <p>
             美しいものを見る（視覚）、その土地の空気を吸う（嗅覚）、心地よいものに触れる（触覚）。
           </p>
-          <p className="mb-8">
+          <p>
             アートに触れる高揚感も、旅先での解放感も、日々のスキンケアの充足感も、すべては繋がっています。
           </p>
-          <p>
-            300本の執筆を通して見つけた、五感を研ぎ澄ませて美しく生きるためのヒントをお届けします。
+          <p className="text-stone-50 italic">
+            300本の執筆を通して見つけた、<br className="md:hidden" />五感を研ぎ澄ませて美しく生きるためのヒント。
           </p>
         </div>
-        
+
         <div className="mt-16 flex justify-center">
-          <div className="w-3 h-3 rounded-full bg-earth-terra opacity-60"></div>
+          <div className="h-2 w-2 rounded-full bg-earth-gold" />
         </div>
       </div>
-      
-      {/* Decorative vertical line */}
-      <div className="absolute left-6 md:left-12 top-32 bottom-32 w-[1px] bg-stone-200 hidden md:block"></div>
-      <div className="absolute right-6 md:right-12 top-32 bottom-32 w-[1px] bg-stone-200 hidden md:block"></div>
     </section>
   );
 };

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,34 +1,49 @@
 import React from 'react';
+import { ArrowUpRight, Instagram } from 'lucide-react';
 
 const Contact: React.FC = () => {
   return (
-    <section id="contact" className="py-24 md:py-32 bg-stone-100">
-      <div className="max-w-screen-md mx-auto px-6 text-center">
-        <span className="block text-xs tracking-[0.3em] text-earth-sage uppercase mb-3">Contact</span>
-        <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-wider mb-8">
-          ご相談・ご依頼
-        </h2>
-        <p className="text-stone-600 leading-loose mb-10">
-          執筆、編集、コンセプト設計のご相談は、以下のメールまたはSNSからご連絡ください。
-          <br />
-          内容を確認後、通常2営業日以内を目安に返信します。
-        </p>
+    <section id="contact" className="bg-stone-50 py-24 md:py-32">
+      <div className="mx-auto max-w-screen-xl px-6">
+        <div className="mb-12 grid grid-cols-1 gap-3 md:mb-16 md:grid-cols-[auto_1fr_auto] md:items-end">
+          <span className="text-[11px] uppercase tracking-[0.4em] text-earth-sage">Chapter 04 — Contact</span>
+          <div aria-hidden="true" className="hidden h-[1px] bg-stone-300 md:block" />
+          <span className="text-[11px] uppercase tracking-[0.4em] text-stone-400">ご相談・ご依頼</span>
+        </div>
 
-        <div className="flex flex-col sm:flex-row gap-4 justify-center">
-          <a
-            href="mailto:contact@sensoria.example"
-            className="px-8 py-3 bg-stone-800 text-stone-50 text-sm tracking-widest hover:bg-earth-terra transition-colors duration-300"
-          >
-            メールで連絡する
-          </a>
-          <a
-            href="https://www.instagram.com/rika05181/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="px-8 py-3 border border-stone-400 text-stone-700 text-sm tracking-widest hover:border-earth-terra hover:text-earth-terra transition-colors duration-300"
-          >
-            Instagramを見る
-          </a>
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.2fr_1fr] md:gap-20 md:items-center">
+          <div>
+            <h2 className="font-serif text-3xl leading-tight text-stone-900 md:text-5xl">
+              企画のご相談から、<br />
+              ご依頼まで。
+            </h2>
+            <p className="mt-8 max-w-xl text-base leading-loose text-stone-600">
+              執筆、編集、コンセプト設計のご相談を承っています。
+              内容を確認後、通常 2 営業日以内を目安に返信します。
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            <a
+              href="mailto:contact@sensoria.example"
+              className="group flex items-center justify-between gap-4 bg-earth-terra px-6 py-5 text-sm tracking-widest text-stone-50 transition-colors hover:bg-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60 focus-visible:ring-offset-2"
+            >
+              <span className="uppercase">メールで連絡する</span>
+              <ArrowUpRight className="h-5 w-5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" aria-hidden="true" />
+            </a>
+            <a
+              href="https://www.instagram.com/rika05181/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group flex items-center justify-between gap-4 border border-stone-400 px-6 py-5 text-sm tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+            >
+              <span className="uppercase inline-flex items-center gap-3">
+                <Instagram className="h-4 w-4" aria-hidden="true" />
+                Instagram で見る
+              </span>
+              <ArrowUpRight className="h-5 w-5" aria-hidden="true" />
+            </a>
+          </div>
         </div>
       </div>
     </section>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -11,6 +11,22 @@ const Hero: React.FC = () => {
         S
       </span>
 
+      {/* Editorial gutter marks (large screens) */}
+      <div aria-hidden="true" className="pointer-events-none absolute left-8 top-1/2 hidden -translate-y-1/2 lg:block">
+        <div className="flex flex-col items-center gap-3 text-[10px] uppercase tracking-[0.4em] text-stone-400">
+          <span className="font-serif text-base text-earth-terra">01</span>
+          <div className="h-16 w-[1px] bg-stone-400" />
+          <span style={{ writingMode: 'vertical-rl' }}>Cover</span>
+        </div>
+      </div>
+      <div aria-hidden="true" className="pointer-events-none absolute right-8 top-1/2 hidden -translate-y-1/2 lg:block">
+        <div className="flex flex-col items-center gap-3 text-[10px] uppercase tracking-[0.4em] text-stone-400">
+          <span className="font-serif text-base text-earth-terra">2026</span>
+          <div className="h-16 w-[1px] bg-stone-400" />
+          <span style={{ writingMode: 'vertical-rl' }}>Vol. 01</span>
+        </div>
+      </div>
+
       {/* Subtle warm radial accent */}
       <div
         aria-hidden="true"

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -2,54 +2,68 @@ import React from 'react';
 
 const Profile: React.FC = () => {
   return (
-    <section id="about" className="py-24 md:py-32 px-6 max-w-screen-xl mx-auto">
-      <div className="flex flex-col lg:flex-row items-center gap-16 lg:gap-24">
-        {/* Image Area */}
-        <div className="w-full lg:w-1/2 relative">
-          <div className="relative aspect-[3/4] w-full max-w-md mx-auto lg:mr-auto">
-             <img 
-              src="https://picsum.photos/id/64/800/1067" 
-              alt="Profile Portrait" 
-              className="w-full h-full object-cover grayscale hover:grayscale-0 transition-all duration-700 ease-out"
-            />
-            <div className="absolute -bottom-6 -right-6 w-full h-full border border-stone-300 -z-10"></div>
-          </div>
+    <section id="about" className="bg-stone-50 py-24 md:py-32">
+      <div className="mx-auto max-w-screen-xl px-6">
+        {/* Section header */}
+        <div className="mb-12 grid grid-cols-1 gap-3 md:mb-16 md:grid-cols-[auto_1fr_auto] md:items-end">
+          <span className="text-[11px] uppercase tracking-[0.4em] text-earth-sage">Chapter 02 — Profile</span>
+          <div aria-hidden="true" className="hidden h-[1px] bg-stone-300 md:block" />
+          <span className="text-[11px] uppercase tracking-[0.4em] text-stone-400">ぺんぺんすけ</span>
         </div>
 
-        {/* Text Area */}
-        <div className="w-full lg:w-1/2">
-          <span className="block text-xs tracking-[0.3em] text-earth-sage uppercase mb-4">About</span>
-          <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-widest mb-8">
-            五感を通じて、<br />美意識を磨く。
-          </h2>
-          
-          <div className="space-y-6 text-stone-600 leading-loose font-serif text-sm md:text-base">
+        {/* Pull-quote: the main visual element */}
+        <blockquote className="mx-auto max-w-3xl text-center">
+          <p className="font-serif text-3xl leading-snug text-stone-900 md:text-5xl md:leading-tight">
+            五感を通じて、<br />
+            <span className="text-earth-terra">美意識を磨く</span>。
+          </p>
+          <footer className="mt-8 text-sm tracking-widest text-stone-500 uppercase">— Editorial Stance</footer>
+        </blockquote>
+
+        {/* Asymmetric: small portrait left, copy right (lg only) */}
+        <div className="mt-20 grid grid-cols-1 gap-12 lg:grid-cols-[240px_1fr] lg:gap-16">
+          <div className="mx-auto lg:mx-0 w-full max-w-[240px]">
+            <div className="relative aspect-[3/4] w-full">
+              <img
+                src="https://picsum.photos/id/64/480/640"
+                alt="Portrait of ぺんぺんすけ (placeholder)"
+                className="h-full w-full object-cover grayscale transition-all duration-700 ease-out hover:grayscale-0"
+              />
+              <div aria-hidden="true" className="absolute -bottom-3 -right-3 h-full w-full border border-stone-300 -z-10" />
+            </div>
+            <div className="mt-6 text-center text-xs tracking-widest text-stone-400 uppercase lg:text-left">
+              Writer / Editor
+            </div>
+          </div>
+
+          <div className="space-y-6 font-serif text-sm leading-loose text-stone-700 md:text-base">
             <p>
-              <strong>ぺんぺんすけ</strong>
-              <br />
               アート、旅、美容をテーマに執筆活動を行うライター・エディター。
-            </p>
-            <p>
               「五感を通じて美意識を磨く」をライフテーマとし、美術館の静寂、異国の風の匂い、上質な化粧品のテクスチャなど、感覚に響く体験を言葉に紡いでいる。
             </p>
             <p>
-              日本経済新聞電子版（日経Web）にてコラムを連載し、通算300本以上の記事を執筆。数字やスペックだけでなく、「どう感じるか」という情緒的価値を伝える執筆スタイルに定評がある。
+              日本経済新聞電子版（日経Web）にてコラムを連載し、通算 300 本以上の記事を執筆。
+              数字やスペックだけでなく、「どう感じるか」という情緒的価値を伝える執筆スタイルに定評がある。
             </p>
             <p>
-              現在はWebメディアのディレクションや、ブランドのコンセプトメイキングを中心に活動中。
+              現在は Web メディアのディレクションや、ブランドのコンセプトメイキングを中心に活動中。
             </p>
-          </div>
 
-          {/* Achievement Summary */}
-          <div className="mt-12 pt-8 border-t border-stone-200 grid grid-cols-2 gap-8">
-             <div>
-                <span className="block text-3xl font-medium font-serif text-earth-gold mb-1">300+</span>
-                <span className="text-xs tracking-widest text-stone-500">ARTICLES WRITTEN</span>
-             </div>
-             <div>
-                <span className="block text-3xl font-medium font-serif text-earth-gold mb-1">10yr</span>
-                <span className="text-xs tracking-widest text-stone-500">EXPERIENCE</span>
-             </div>
+            {/* Achievement strip — minimal, no boxes */}
+            <dl className="mt-12 grid grid-cols-2 gap-8 border-t border-stone-200 pt-8 md:grid-cols-3">
+              <div>
+                <dt className="text-[11px] uppercase tracking-widest text-stone-500">Articles</dt>
+                <dd className="mt-2 font-serif text-3xl text-earth-gold md:text-4xl">300+</dd>
+              </div>
+              <div>
+                <dt className="text-[11px] uppercase tracking-widest text-stone-500">Experience</dt>
+                <dd className="mt-2 font-serif text-3xl text-earth-gold md:text-4xl">10yr</dd>
+              </div>
+              <div className="col-span-2 md:col-span-1">
+                <dt className="text-[11px] uppercase tracking-widest text-stone-500">Themes</dt>
+                <dd className="mt-2 font-serif text-base text-stone-800 leading-relaxed">Beauty / Travel / Editorial</dd>
+              </div>
+            </dl>
           </div>
         </div>
       </div>

--- a/components/Works.tsx
+++ b/components/Works.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { ArrowUpRight } from 'lucide-react';
 
 type SummaryItem = {
   value: string;
@@ -6,51 +7,52 @@ type SummaryItem = {
 };
 
 const summaryItems: SummaryItem[] = [
-  {
-    value: '300+',
-    label: 'ARTICLES',
-  },
-  {
-    value: '5',
-    label: 'CATEGORIES',
-  },
-  {
-    value: '1',
-    label: 'WORKS HUB',
-  },
+  { value: '300+', label: 'Articles' },
+  { value: '5', label: 'Categories' },
+  { value: '30+', label: 'Linked Pieces' },
 ];
 
 const Works: React.FC = () => {
   return (
-    <section id="works" className="py-24 md:py-32 px-6 max-w-screen-xl mx-auto">
-      <div className="grid grid-cols-1 lg:grid-cols-[0.9fr_1.1fr] gap-12 lg:gap-16 items-center">
-        <div>
-          <span className="block text-xs tracking-[0.3em] text-earth-sage uppercase mb-3">Works</span>
-          <h2 className="text-3xl md:text-4xl font-medium font-serif text-stone-800 tracking-wider mb-6">活動と実績</h2>
-          <p className="text-sm md:text-base text-stone-600 leading-loose mb-8">
-            執筆、取材、音声配信、外部掲載の実績は専用ページに集約しています。
-            TOPでは概要だけを伝え、詳細なカテゴリと掲載リンクは実績ページで確認できます。
-          </p>
-          <a
-            href="#/works"
-            className="inline-block px-8 py-3 bg-stone-800 text-stone-50 text-sm tracking-widest hover:bg-earth-terra transition-colors duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
-          >
-            実績ページを見る
-          </a>
+    <section id="works" className="relative bg-stone-100">
+      {/* Inset terra strip — gives the section a clear visual anchor */}
+      <div aria-hidden="true" className="absolute inset-x-0 top-0 h-1 bg-earth-terra" />
+
+      <div className="mx-auto max-w-screen-xl px-6 py-24 md:py-32">
+        <div className="mb-12 grid grid-cols-1 gap-3 md:mb-16 md:grid-cols-[auto_1fr_auto] md:items-end">
+          <span className="text-[11px] uppercase tracking-[0.4em] text-earth-sage">Chapter 03 — Works</span>
+          <div aria-hidden="true" className="hidden h-[1px] bg-stone-300 md:block" />
+          <span className="text-[11px] uppercase tracking-[0.4em] text-stone-400">活動と実績</span>
         </div>
 
-        <div className="border-y border-stone-200 py-8 md:py-10">
-          <div className="grid grid-cols-3 gap-6">
-          {summaryItems.map((item) => (
-            <div key={item.label}>
-              <span className="block text-3xl md:text-4xl font-serif text-earth-gold mb-2">{item.value}</span>
-              <span className="text-[11px] md:text-xs tracking-widest text-stone-500">{item.label}</span>
-            </div>
-          ))}
+        <div className="grid grid-cols-1 gap-12 md:grid-cols-[1.1fr_1fr] md:gap-20 md:items-end">
+          <div>
+            <h2 className="font-serif text-4xl leading-tight text-stone-900 md:text-6xl">
+              読まれる文脈に、<br />
+              <span className="text-earth-terra">書く</span>。
+            </h2>
+            <p className="mt-8 max-w-xl text-base leading-loose text-stone-600">
+              執筆、取材、音声配信、外部掲載までの活動を専用ページに集約しています。
+              媒体ごとのトーンを大切にしながら、体験の感触を残す記録を続けてきました。
+            </p>
+            <a
+              href="#/works"
+              className="mt-10 inline-flex items-center gap-3 bg-stone-900 px-6 py-4 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:bg-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+            >
+              実績ページを見る
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </a>
           </div>
-          <p className="mt-8 text-sm text-stone-500 leading-loose">
-            実績ページでは、主要リンク、活動カテゴリ、掲載リンクの順で整理しています。
-          </p>
+
+          {/* Numbers strip — no boxes, just typography */}
+          <dl className="grid grid-cols-3 gap-6 border-t border-stone-300 pt-10">
+            {summaryItems.map((item) => (
+              <div key={item.label}>
+                <dt className="text-[11px] uppercase tracking-widest text-stone-500">{item.label}</dt>
+                <dd className="mt-3 font-serif text-3xl text-earth-gold md:text-5xl">{item.value}</dd>
+              </div>
+            ))}
+          </dl>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
"四角ボックスが似たような繰り返しでフラット" "色がモノクロすぎる" "セクションの章感が出ていない" のフィードバックに応える、ホームページの視覚的な刷新。

### 変更箇所
| Section | 変更 |
|---|---|
| Hero | 左右に縦書きの編集記号（Cover / 2026 / Vol.01）+ 細罫 |
| **Concept** | **stone-50 → stone-900 のダーク帯に逆転**（ページ最初の章切れを作る）。earth-gold アクセント |
| Profile | pull-quote を主役に。ポートレートを 240px に縮小、achievement の枠を撤廃して dl strip に |
| Works | 全幅 stone-100 バンド + 上端に terra 1px ライン。CTA は stone-900 → terra hover |
| Contact | 中央カード型を廃止。2カラム + mail を terra solid の主役 CTA に |

各セクションに \`Chapter NN — ...\` のささやかな見出しを追加してリズムを刻む。

### 期待される効果
- スクロール中に「章が変わった」という体感が出る
- ページ全体での earth-terra / earth-sage / earth-gold の出現頻度が上がり、配色が実装された印象になる
- 似た bordered-card の数が減り、各セクションが固有の構造を持つ

## Notes
- ぺんぺんすけ表示は Profile に小さくキャプションとして配置
- ポートレートは Picsum 暫定のまま（ユーザー指定）
- Featured（Works ページ側）は別 PR で扱う

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Concept のダーク帯が章切れとして機能するか
- [ ] preview で Hero の左右の編集記号が PC のみ表示されること
- [ ] preview でモバイルでも各セクションが崩れないこと
- [ ] preview で Contact の terra ボタンが目を引く位置にあること

🤖 Generated with [Claude Code](https://claude.com/claude-code)