### PR TITLE
chore tone down decorative orange across the site

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -26,7 +26,7 @@ const Contact: React.FC = () => {
           <div className="space-y-3">
             <a
               href="mailto:contact@sensoria.example"
-              className="group flex items-center justify-between gap-4 bg-earth-terra px-6 py-5 text-sm tracking-widest text-stone-50 transition-colors hover:bg-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60 focus-visible:ring-offset-2"
+              className="group flex items-center justify-between gap-4 bg-stone-900 px-6 py-5 text-sm tracking-widest text-stone-50 transition-colors hover:bg-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
             >
               <span className="uppercase">メールで連絡する</span>
               <ArrowUpRight className="h-5 w-5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" aria-hidden="true" />

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -14,14 +14,14 @@ const Hero: React.FC = () => {
       {/* Editorial gutter marks (large screens) */}
       <div aria-hidden="true" className="pointer-events-none absolute left-8 top-1/2 hidden -translate-y-1/2 lg:block">
         <div className="flex flex-col items-center gap-3 text-[10px] uppercase tracking-[0.4em] text-stone-400">
-          <span className="font-serif text-base text-earth-terra">01</span>
+          <span className="font-serif text-base text-stone-700">01</span>
           <div className="h-16 w-[1px] bg-stone-400" />
           <span style={{ writingMode: 'vertical-rl' }}>Cover</span>
         </div>
       </div>
       <div aria-hidden="true" className="pointer-events-none absolute right-8 top-1/2 hidden -translate-y-1/2 lg:block">
         <div className="flex flex-col items-center gap-3 text-[10px] uppercase tracking-[0.4em] text-stone-400">
-          <span className="font-serif text-base text-earth-terra">2026</span>
+          <span className="font-serif text-base text-stone-700">2026</span>
           <div className="h-16 w-[1px] bg-stone-400" />
           <span style={{ writingMode: 'vertical-rl' }}>Vol. 01</span>
         </div>

--- a/components/MediaKitPage.tsx
+++ b/components/MediaKitPage.tsx
@@ -43,7 +43,7 @@ const MediaKitPage: React.FC = () => {
               </p>
             </div>
             <div className="border border-stone-200 bg-stone-50/90 p-6 backdrop-blur">
-              <Sparkles className="h-6 w-6 text-earth-terra" aria-hidden="true" />
+              <Sparkles className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <p className="mt-6 font-serif text-2xl leading-relaxed text-stone-900">
                 五感を切り口に、体験と読者の暮らしをつなぐ発信者。
               </p>
@@ -64,7 +64,7 @@ const MediaKitPage: React.FC = () => {
             <div className="grid grid-cols-1 gap-px overflow-hidden border border-stone-200 bg-stone-200 md:grid-cols-3">
               {profileFacts.map(([label, value]) => (
                 <div key={label} className="bg-stone-50 p-6">
-                  <span className="text-xs uppercase tracking-widest text-earth-terra">{label}</span>
+                  <span className="text-xs uppercase tracking-widest text-stone-500">{label}</span>
                   <p className="mt-4 text-sm leading-loose text-stone-700">{value}</p>
                 </div>
               ))}
@@ -75,7 +75,7 @@ const MediaKitPage: React.FC = () => {
         <section className="border-y border-stone-200 bg-stone-100/70">
           <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-8 px-6 py-16 md:grid-cols-3 md:py-20">
             <article className="bg-stone-50 p-6">
-              <MessageSquareText className="h-6 w-6 text-earth-terra" aria-hidden="true" />
+              <MessageSquareText className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl text-stone-900">話せるテーマ</h3>
               <ul className="mt-6 space-y-4">
                 {topics.map((topic) => (
@@ -87,7 +87,7 @@ const MediaKitPage: React.FC = () => {
             </article>
 
             <article className="bg-stone-50 p-6">
-              <Newspaper className="h-6 w-6 text-earth-terra" aria-hidden="true" />
+              <Newspaper className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl text-stone-900">掲載・発信先</h3>
               <div className="mt-6 flex flex-wrap gap-2">
                 {pressMentions.map((name) => (

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -15,7 +15,7 @@ const Profile: React.FC = () => {
         <blockquote className="mx-auto max-w-3xl text-center">
           <p className="font-serif text-3xl leading-snug text-stone-900 md:text-5xl md:leading-tight">
             五感を通じて、<br />
-            <span className="text-earth-terra">美意識を磨く</span>。
+            <em className="not-italic font-serif">美意識を磨く</em>。
           </p>
           <footer className="mt-8 text-sm tracking-widest text-stone-500 uppercase">— Editorial Stance</footer>
         </blockquote>

--- a/components/Works.tsx
+++ b/components/Works.tsx
@@ -15,9 +15,6 @@ const summaryItems: SummaryItem[] = [
 const Works: React.FC = () => {
   return (
     <section id="works" className="relative bg-stone-100">
-      {/* Inset terra strip — gives the section a clear visual anchor */}
-      <div aria-hidden="true" className="absolute inset-x-0 top-0 h-1 bg-earth-terra" />
-
       <div className="mx-auto max-w-screen-xl px-6 py-24 md:py-32">
         <div className="mb-12 grid grid-cols-1 gap-3 md:mb-16 md:grid-cols-[auto_1fr_auto] md:items-end">
           <span className="text-[11px] uppercase tracking-[0.4em] text-earth-sage">Chapter 03 — Works</span>
@@ -29,7 +26,7 @@ const Works: React.FC = () => {
           <div>
             <h2 className="font-serif text-4xl leading-tight text-stone-900 md:text-6xl">
               読まれる文脈に、<br />
-              <span className="text-earth-terra">書く</span>。
+              <em className="not-italic font-serif">書く</em>。
             </h2>
             <p className="mt-8 max-w-xl text-base leading-loose text-stone-600">
               執筆、取材、音声配信、外部掲載までの活動を専用ページに集約しています。

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -220,7 +220,7 @@ const WorksPage: React.FC = () => {
                     <h4 className="mt-3 font-serif text-2xl leading-relaxed text-stone-900">{work.title}</h4>
                     <p className="mt-4 text-sm leading-loose text-stone-600">{work.summary}</p>
                     {work.quote && (
-                      <blockquote className="mt-5 border-l-2 border-earth-terra pl-4 font-serif text-sm italic leading-loose text-earth-sage">
+                      <blockquote className="mt-5 border-l-2 border-stone-300 pl-4 font-serif text-sm italic leading-loose text-stone-600">
                         “{work.quote}”
                       </blockquote>
                     )}
@@ -252,7 +252,7 @@ const WorksPage: React.FC = () => {
                 const Icon = categoryIcons[index] ?? Sparkles;
                 return (
                   <article key={item.title} className="bg-stone-50 p-5 md:p-6">
-                    <Icon className="h-5 w-5 text-earth-terra" aria-hidden="true" />
+                    <Icon className="h-5 w-5 text-stone-600" aria-hidden="true" />
                     <span className="mt-5 block text-xs uppercase tracking-widest text-stone-500">{item.category}</span>
                     <h4 className="mt-3 font-serif text-lg leading-relaxed text-stone-900">{item.title}</h4>
                     <p className="mt-4 text-sm leading-loose text-stone-600">{item.overview}</p>


### PR DESCRIPTION
## Summary
オレンジ（earth-terra）の装飾的な使用が、参考画像から見えるブランドトーン（高級・夜景・建築）と噛み合わず "クラフト寄り" に見える件を修正。装飾用途は無彩色（stone-600/700）に置換し、orange は **インタラクション（ホバー / 選択中の active）** にだけ残す。

## Changes
| 場所 | Before | After |
|---|---|---|
| Hero gutter "01" / "2026" | text-earth-terra | text-stone-700 |
| Profile heading "美意識を磨く" | terra span | serif emphasis（色なし） |
| Works heading "書く" | terra span | serif emphasis（色なし） |
| Works section top | bg-earth-terra 1px ストリップ | 撤去 |
| Featured blockquote | border terra + text sage | border stone-300 + text stone-600 |
| Expertise アイコン群 | text-earth-terra | text-stone-600 |
| MediaKit Hero アイコン群 | text-earth-terra | text-stone-600 |
| MediaKit Profile fact ラベル | text-earth-terra | text-stone-500 |
| Contact メール CTA | bg-earth-terra | bg-stone-900（hover stone-700） |

## 残した orange
- フィルタチップの active 状態
- Sticky nav の active カテゴリ
- "View" / "Read" 等のリンクアクション hover
- focus-visible リング（一部）

これらは "インタラクションの合図" として機能しているので、見た目改善より UX を優先して維持。

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Hero / Profile / Works / Contact から目立つ orange が消えていること
- [ ] preview でフィルタチップ等の active 表示はまだ orange であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)