### PR TITLE
feat establish unified design color system

### DIFF
--- a/components/Concept.tsx
+++ b/components/Concept.tsx
@@ -13,9 +13,9 @@ const Concept: React.FC = () => {
 
       <div className="max-w-screen-md mx-auto px-6">
         <div className="text-center mb-14">
-          <span className="block text-xs tracking-[0.4em] text-earth-gold uppercase mb-5">Introduction</span>
+          <span className="block text-xs tracking-[0.4em] text-earth-sage uppercase mb-5">Introduction</span>
           <h2 className="text-3xl md:text-5xl font-medium font-serif text-stone-50 tracking-widest">五感美容とは</h2>
-          <div className="mt-6 mx-auto h-[1px] w-16 bg-earth-gold/60" />
+          <div className="mt-6 mx-auto h-[1px] w-16 bg-stone-500" />
         </div>
 
         <div className="font-serif text-stone-200 leading-loose text-justify md:text-center space-y-8 text-base md:text-lg">
@@ -31,7 +31,7 @@ const Concept: React.FC = () => {
         </div>
 
         <div className="mt-16 flex justify-center">
-          <div className="h-2 w-2 rounded-full bg-earth-gold" />
+          <div className="h-2 w-2 rounded-full bg-stone-400" />
         </div>
       </div>
     </section>

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -35,7 +35,7 @@ const Contact: React.FC = () => {
               href="https://www.instagram.com/rika05181/"
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex items-center justify-between gap-4 border border-stone-400 px-6 py-5 text-sm tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+              className="group flex items-center justify-between gap-4 border border-stone-400 px-6 py-5 text-sm tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
             >
               <span className="uppercase inline-flex items-center gap-3">
                 <Instagram className="h-4 w-4" aria-hidden="true" />

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -39,7 +39,7 @@ const Header: React.FC = () => {
             <a
               key={item.label}
               href={item.href}
-              className="text-sm font-medium tracking-widest text-stone-600 hover:text-earth-terra transition-colors uppercase"
+              className="text-sm font-medium tracking-widest text-stone-600 hover:text-stone-900 transition-colors uppercase"
             >
               {item.label}
             </a>
@@ -50,7 +50,7 @@ const Header: React.FC = () => {
               target="_blank"
               rel="noopener noreferrer"
               aria-label="Instagram"
-              className="text-stone-500 hover:text-earth-terra transition-colors"
+              className="text-stone-500 hover:text-stone-900 transition-colors"
             >
               <Instagram size={18} />
             </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -33,7 +33,7 @@ const Hero: React.FC = () => {
         className="pointer-events-none absolute inset-0"
         style={{
           background:
-            'radial-gradient(circle at 50% 30%, rgba(180, 83, 9, 0.05), transparent 55%)',
+            'radial-gradient(circle at 50% 30%, rgba(28, 25, 23, 0.04), transparent 55%)',
         }}
       />
 

--- a/components/Issue15AuditPage.tsx
+++ b/components/Issue15AuditPage.tsx
@@ -98,7 +98,7 @@ const SelectField = <Value extends string>({ label, value, labels, onChange }: S
     <select
       value={value}
       onChange={(event) => onChange(event.target.value as Value)}
-      className="mt-2 w-full border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+      className="mt-2 w-full border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-stone-900 focus:ring-2 focus:ring-stone-300"
     >
       {Object.entries(labels).map(([optionValue, optionLabel]) => (
         <option key={optionValue} value={optionValue}>
@@ -221,11 +221,11 @@ const Issue15AuditPage: React.FC = () => {
     <div className="min-h-screen bg-stone-50 text-stone-800">
       <header className="sticky top-0 z-20 border-b border-stone-200 bg-stone-50/95 backdrop-blur">
         <div className="mx-auto flex max-w-screen-xl items-center justify-between px-6 py-5">
-          <a href="#/works" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-earth-terra">
+          <a href="#/works" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-stone-900">
             Works
           </a>
           <p className="text-sm tracking-widest text-stone-500">Issue #15 Audit</p>
-          <a href="#" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-earth-terra">
+          <a href="#" className="text-sm uppercase tracking-widest text-stone-600 transition-colors hover:text-stone-900">
             Top
           </a>
         </div>
@@ -255,7 +255,7 @@ const Issue15AuditPage: React.FC = () => {
             ['未判定', pending],
           ].map(([label, value]) => (
             <div key={label} className="border border-stone-200 bg-white p-5">
-              <span className="block font-serif text-3xl text-earth-gold">{value}</span>
+              <span className="block font-serif text-3xl text-stone-900">{value}</span>
               <span className="mt-2 block text-xs tracking-widest text-stone-500">{label}</span>
             </div>
           ))}
@@ -263,7 +263,7 @@ const Issue15AuditPage: React.FC = () => {
 
         <section className="mb-8 border border-stone-200 bg-white p-5 md:p-6">
           <div className="flex items-start gap-3">
-            <FileSearch className="mt-1 h-5 w-5 flex-none text-earth-terra" aria-hidden="true" />
+            <FileSearch className="mt-1 h-5 w-5 flex-none text-stone-700" aria-hidden="true" />
             <div>
               <h2 className="font-serif text-xl text-stone-900">チェックランの順序</h2>
               <p className="mt-2 text-sm leading-loose text-stone-600">
@@ -285,7 +285,7 @@ const Issue15AuditPage: React.FC = () => {
                 <button
                   type="button"
                   onClick={copyExportJson}
-                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900"
                 >
                   <Copy className="h-4 w-4" aria-hidden="true" />
                   JSONをコピー
@@ -293,7 +293,7 @@ const Issue15AuditPage: React.FC = () => {
                 <button
                   type="button"
                   onClick={downloadExportJson}
-                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                  className="inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900"
                 >
                   <Download className="h-4 w-4" aria-hidden="true" />
                   JSONを保存
@@ -317,12 +317,12 @@ const Issue15AuditPage: React.FC = () => {
                 onChange={(event) => setImportText(event.target.value)}
                 rows={8}
                 placeholder="保存済みのJSONを貼り付け"
-                className="mt-4 w-full border border-stone-200 bg-stone-50 px-3 py-2 font-mono text-xs leading-relaxed text-stone-700 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+                className="mt-4 w-full border border-stone-200 bg-stone-50 px-3 py-2 font-mono text-xs leading-relaxed text-stone-700 outline-none transition-colors focus:border-stone-900 focus:ring-2 focus:ring-stone-300"
               />
               <button
                 type="button"
                 onClick={importJson}
-                className="mt-3 inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                className="mt-3 inline-flex items-center gap-2 border border-stone-300 bg-white px-4 py-2 text-xs tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900"
               >
                 <Upload className="h-4 w-4" aria-hidden="true" />
                 JSONを取り込む
@@ -348,7 +348,7 @@ const Issue15AuditPage: React.FC = () => {
                     href={item.url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="mt-4 inline-flex items-center gap-2 break-all text-sm text-earth-terra transition-colors hover:text-stone-900"
+                    className="mt-4 inline-flex items-center gap-2 break-all text-sm text-stone-700 transition-colors hover:text-stone-900"
                   >
                     {item.url}
                     <ExternalLink className="h-4 w-4 flex-none" aria-hidden="true" />
@@ -396,12 +396,12 @@ const Issue15AuditPage: React.FC = () => {
                       type="date"
                       value={item.checkedAt ?? ''}
                       onChange={(event) => updateCandidate(item.id, 'checkedAt', event.target.value || null)}
-                      className="min-w-0 flex-1 border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+                      className="min-w-0 flex-1 border border-stone-200 bg-white px-3 py-2 text-sm text-stone-800 outline-none transition-colors focus:border-stone-900 focus:ring-2 focus:ring-stone-300"
                     />
                     <button
                       type="button"
                       onClick={() => markCheckedNow(item.id)}
-                      className="border border-stone-300 bg-white px-3 py-2 text-xs tracking-widest text-stone-600 transition-colors hover:border-earth-terra hover:text-earth-terra"
+                      className="border border-stone-300 bg-white px-3 py-2 text-xs tracking-widest text-stone-600 transition-colors hover:border-stone-900 hover:text-stone-900"
                     >
                       今日
                     </button>
@@ -416,7 +416,7 @@ const Issue15AuditPage: React.FC = () => {
                     value={item.notes}
                     onChange={(event) => updateCandidate(item.id, 'notes', event.target.value)}
                     rows={3}
-                    className="mt-2 w-full border border-stone-200 bg-stone-50 px-3 py-2 text-sm leading-loose text-stone-700 outline-none transition-colors focus:border-earth-terra focus:ring-2 focus:ring-earth-terra/20"
+                    className="mt-2 w-full border border-stone-200 bg-stone-50 px-3 py-2 text-sm leading-loose text-stone-700 outline-none transition-colors focus:border-stone-900 focus:ring-2 focus:ring-stone-300"
                   />
                 </div>
               </div>

--- a/components/MediaKitPage.tsx
+++ b/components/MediaKitPage.tsx
@@ -47,7 +47,7 @@ const MediaKitPage: React.FC = () => {
               <p className="mt-6 font-serif text-2xl leading-relaxed text-stone-900">
                 五感を切り口に、体験と読者の暮らしをつなぐ発信者。
               </p>
-              <a href="#media-kit-profile" className="mt-8 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-earth-terra">
+              <a href="#media-kit-profile" className="mt-8 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-stone-700">
                 View Profile
                 <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
               </a>
@@ -99,12 +99,12 @@ const MediaKitPage: React.FC = () => {
             </article>
 
             <article className="bg-stone-900 p-6 text-stone-50">
-              <BriefcaseBusiness className="h-6 w-6 text-earth-gold" aria-hidden="true" />
+              <BriefcaseBusiness className="h-6 w-6 text-stone-900" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl">依頼の相談</h3>
               <p className="mt-6 text-sm leading-loose text-stone-300">
                 記事制作、体験取材、音声企画、アンバサダー相談など、媒体や目的に合わせて整理できます。
               </p>
-              <a href="#contact" className="mt-8 inline-flex items-center gap-2 border border-stone-500 px-4 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-earth-terra hover:text-earth-terra">
+              <a href="#contact" className="mt-8 inline-flex items-center gap-2 border border-stone-500 px-4 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:text-stone-900">
                 Contact
                 <Mail className="h-4 w-4" aria-hidden="true" />
               </a>
@@ -121,7 +121,7 @@ const MediaKitPage: React.FC = () => {
                 #15 の根拠確認が進んだら、媒体掲載履歴や専門領域別実績をこのページにも反映します。
               </p>
             </div>
-            <a href="#/works" className="inline-flex items-center justify-center gap-2 border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra">
+            <a href="#/works" className="inline-flex items-center justify-center gap-2 border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
               <Download className="h-4 w-4" aria-hidden="true" />
               Works
             </a>

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -53,11 +53,11 @@ const Profile: React.FC = () => {
             <dl className="mt-12 grid grid-cols-2 gap-8 border-t border-stone-200 pt-8 md:grid-cols-3">
               <div>
                 <dt className="text-[11px] uppercase tracking-widest text-stone-500">Articles</dt>
-                <dd className="mt-2 font-serif text-3xl text-earth-gold md:text-4xl">300+</dd>
+                <dd className="mt-2 font-serif text-3xl text-stone-900 md:text-4xl">300+</dd>
               </div>
               <div>
                 <dt className="text-[11px] uppercase tracking-widest text-stone-500">Experience</dt>
-                <dd className="mt-2 font-serif text-3xl text-earth-gold md:text-4xl">10yr</dd>
+                <dd className="mt-2 font-serif text-3xl text-stone-900 md:text-4xl">10yr</dd>
               </div>
               <div className="col-span-2 md:col-span-1">
                 <dt className="text-[11px] uppercase tracking-widest text-stone-500">Themes</dt>

--- a/components/Works.tsx
+++ b/components/Works.tsx
@@ -34,7 +34,7 @@ const Works: React.FC = () => {
             </p>
             <a
               href="#/works"
-              className="mt-10 inline-flex items-center gap-3 bg-stone-900 px-6 py-4 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:bg-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+              className="mt-10 inline-flex items-center gap-3 bg-stone-900 px-6 py-4 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:bg-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
             >
               実績ページを見る
               <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
@@ -46,7 +46,7 @@ const Works: React.FC = () => {
             {summaryItems.map((item) => (
               <div key={item.label}>
                 <dt className="text-[11px] uppercase tracking-widest text-stone-500">{item.label}</dt>
-                <dd className="mt-3 font-serif text-3xl text-earth-gold md:text-5xl">{item.value}</dd>
+                <dd className="mt-3 font-serif text-3xl text-stone-900 md:text-5xl">{item.value}</dd>
               </div>
             ))}
           </dl>

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -106,7 +106,7 @@ const WorksPage: React.FC = () => {
     <div className="min-h-screen bg-stone-50 text-stone-800">
       <a
         href="#link-library"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:bg-stone-900 focus:px-4 focus:py-2 focus:text-sm focus:tracking-widest focus:text-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra"
+        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-50 focus:bg-stone-900 focus:px-4 focus:py-2 focus:text-sm focus:tracking-widest focus:text-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
       >
         Skip to categories
       </a>
@@ -132,13 +132,13 @@ const WorksPage: React.FC = () => {
                 美容、旅、アート、文化、音声配信まで。媒体ごとの文脈に寄り添いながら、体験を言葉と導線に整えてきた活動をまとめています。
               </p>
               <div className="mt-8 flex flex-wrap gap-3">
-                <a href="#featured-works" className="border border-stone-800 bg-stone-800 px-5 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-earth-terra hover:bg-earth-terra">
+                <a href="#featured-works" className="border border-stone-800 bg-stone-800 px-5 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:bg-stone-700">
                   Featured
                 </a>
-                <a href="#link-library" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra">
+                <a href="#link-library" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
                   Link Library
                 </a>
-                <a href="#/media-kit" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra">
+                <a href="#/media-kit" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
                   Media Kit
                 </a>
               </div>
@@ -147,7 +147,7 @@ const WorksPage: React.FC = () => {
             <div className="relative z-10 grid grid-cols-1 gap-3">
               {worksMetrics.map((metric) => (
                 <div key={metric.label} className="border border-stone-200 bg-stone-50/90 p-5 backdrop-blur">
-                  <span className="block font-serif text-4xl text-earth-gold">{metric.value}</span>
+                  <span className="block font-serif text-4xl text-stone-900">{metric.value}</span>
                   <span className="mt-2 block text-xs uppercase tracking-widest text-stone-500">{metric.label}</span>
                   <p className="mt-3 text-sm leading-relaxed text-stone-600">{metric.note}</p>
                 </div>
@@ -190,7 +190,7 @@ const WorksPage: React.FC = () => {
                   href={work.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex flex-col overflow-hidden border border-stone-200 bg-stone-50 transition-colors hover:border-earth-terra/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                  className="group flex flex-col overflow-hidden border border-stone-200 bg-stone-50 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
                 >
                   <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-stone-100 via-stone-200 to-stone-300">
                     {work.keyVisual ? (
@@ -224,7 +224,7 @@ const WorksPage: React.FC = () => {
                         “{work.quote}”
                       </blockquote>
                     )}
-                    <span className="mt-auto pt-6 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-stone-500 transition-colors group-hover:text-earth-terra">
+                    <span className="mt-auto pt-6 inline-flex items-center gap-2 text-xs uppercase tracking-widest text-stone-500 transition-colors group-hover:text-stone-900">
                       View
                       <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                     </span>
@@ -283,7 +283,7 @@ const WorksPage: React.FC = () => {
                 <button
                   type="button"
                   onClick={clearTopics}
-                  className="text-[11px] uppercase tracking-widest text-earth-terra transition-colors hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                  className="text-[11px] uppercase tracking-widest text-stone-700 transition-colors hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
                 >
                   Clear ({activeTopics.length})
                 </button>
@@ -300,8 +300,8 @@ const WorksPage: React.FC = () => {
                     aria-pressed={isActive}
                     className={
                       isActive
-                        ? 'border border-earth-terra bg-earth-terra px-3 py-1.5 text-xs text-stone-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60'
-                        : 'border border-stone-300 bg-stone-50 px-3 py-1.5 text-xs text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60'
+                        ? 'border border-stone-900 bg-stone-900 px-3 py-1.5 text-xs text-stone-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900'
+                        : 'border border-stone-300 bg-stone-50 px-3 py-1.5 text-xs text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900'
                     }
                   >
                     {topic}
@@ -323,10 +323,10 @@ const WorksPage: React.FC = () => {
                   key={category.name}
                   href={`#works-${category.slug}`}
                   className={
-                    'flex-none border px-4 py-2 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60 ' +
+                    'flex-none border px-4 py-2 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 ' +
                     (isActive
-                      ? 'border-earth-terra bg-earth-terra/10 text-earth-terra'
-                      : 'border-stone-200 bg-stone-50 text-stone-700 hover:border-earth-terra/60 hover:text-earth-terra')
+                      ? 'border-stone-900 bg-stone-100 text-stone-900'
+                      : 'border-stone-200 bg-stone-50 text-stone-700 hover:border-stone-700 hover:text-stone-900')
                   }
                 >
                   <span className="font-serif text-sm">{category.name}</span>
@@ -343,7 +343,7 @@ const WorksPage: React.FC = () => {
               <button
                 type="button"
                 onClick={clearTopics}
-                className="mt-6 inline-flex items-center gap-2 border border-stone-400 px-5 py-2 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-earth-terra hover:text-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                className="mt-6 inline-flex items-center gap-2 border border-stone-400 px-5 py-2 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
               >
                 Clear filters
               </button>
@@ -361,11 +361,11 @@ const WorksPage: React.FC = () => {
               >
                 <div className="grid grid-cols-1 gap-5 lg:grid-cols-[280px_1fr] lg:gap-10">
                   <div>
-                    <span className="text-xs uppercase tracking-widest text-earth-terra">{category.items.length} Links</span>
+                    <span className="text-xs uppercase tracking-widest text-stone-700">{category.items.length} Links</span>
                     <h4
                       id={`works-heading-${category.slug}`}
                       tabIndex={-1}
-                      className="mt-3 font-serif text-2xl text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                      className="mt-3 font-serif text-2xl text-stone-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
                     >
                       {category.name}
                     </h4>
@@ -385,7 +385,7 @@ const WorksPage: React.FC = () => {
                           href={link.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="work-link group border border-stone-200 bg-stone-50 px-5 py-4 transition-colors hover:border-earth-terra/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60"
+                          className="work-link group border border-stone-200 bg-stone-50 px-5 py-4 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
                         >
                           <p className="work-title text-sm leading-relaxed text-stone-800 md:text-base">{link.title}</p>
                           {metaParts.length > 0 && (
@@ -395,7 +395,7 @@ const WorksPage: React.FC = () => {
                           )}
                           <div className="mt-4 flex items-center justify-between gap-4 text-[11px] uppercase tracking-widest">
                             <span className="min-w-0 truncate text-stone-500">{getDomainLabel(link.url)}</span>
-                            <span className="inline-flex flex-none items-center gap-1 text-earth-terra">
+                            <span className="inline-flex flex-none items-center gap-1 text-stone-700">
                               {getCta(link)}
                               <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
                             </span>
@@ -408,14 +408,14 @@ const WorksPage: React.FC = () => {
                         href={category.viewAllUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="group flex flex-col justify-between border border-dashed border-stone-300 bg-stone-50 px-5 py-4 transition-colors hover:border-earth-terra/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra/60 md:col-span-2"
+                        className="group flex flex-col justify-between border border-dashed border-stone-300 bg-stone-50 px-5 py-4 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 md:col-span-2"
                       >
                         <p className="font-serif text-base leading-relaxed text-stone-800 md:text-lg">
                           {category.viewAllLabel ?? 'すべて見る'}
                         </p>
                         <div className="mt-4 flex items-center justify-between gap-4 text-[11px] uppercase tracking-widest">
                           <span className="min-w-0 truncate text-stone-500">{getDomainLabel(category.viewAllUrl)}</span>
-                          <span className="inline-flex flex-none items-center gap-1 text-earth-terra">
+                          <span className="inline-flex flex-none items-center gap-1 text-stone-700">
                             View all
                             <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
                           </span>
@@ -434,7 +434,7 @@ const WorksPage: React.FC = () => {
           <div className="mx-auto max-w-screen-xl px-6 py-14 md:py-20">
             <div className="grid grid-cols-1 gap-10 md:grid-cols-[1fr_auto] md:items-center">
               <div>
-                <span className="block text-xs uppercase tracking-[0.3em] text-earth-gold">For Editors / Partners</span>
+                <span className="block text-xs uppercase tracking-[0.3em] text-stone-900">For Editors / Partners</span>
                 <h3 className="mt-3 font-serif text-3xl leading-tight md:text-4xl">取材・寄稿・依頼の方へ</h3>
                 <p className="mt-4 max-w-2xl text-sm leading-loose text-stone-300">
                   媒体やテーマに合わせた企画にも対応しています。まずはメディアキットで概要をご確認の上、ご相談ください。
@@ -443,14 +443,14 @@ const WorksPage: React.FC = () => {
               <div className="flex flex-col gap-3 sm:flex-row">
                 <a
                   href="#contact"
-                  className="inline-flex items-center justify-center gap-2 bg-stone-50 px-6 py-3 text-xs uppercase tracking-widest text-stone-900 transition-colors hover:bg-earth-terra hover:text-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
+                  className="inline-flex items-center justify-center gap-2 bg-stone-50 px-6 py-3 text-xs uppercase tracking-widest text-stone-900 transition-colors hover:bg-stone-700 hover:text-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
                 >
                   Contact
                   <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>
                 <a
                   href="#/media-kit"
-                  className="inline-flex items-center justify-center gap-2 border border-stone-500 px-6 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-earth-terra hover:text-earth-terra focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-earth-terra focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
+                  className="inline-flex items-center justify-center gap-2 border border-stone-500 px-6 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
                 >
                   Media Kit
                   <ArrowUpRight className="h-4 w-4" aria-hidden="true" />

--- a/docs/02-design-guide.md
+++ b/docs/02-design-guide.md
@@ -9,14 +9,60 @@
   - 過剰な影・過剰なアニメーション
 
 ## 2. Colors
-- Background: `stone-50` (`#fafaf9`)
-- Surface: `stone-100` (`#f5f5f4`)
-- Text primary: `stone-900` (`#1c1917`)
-- Text secondary: `stone-800` (`#292524`)
-- Accent 1: `earth-terra` (`#b45309`)
-- Accent 2: `earth-sage` (`#4d7c5f`)
-- Accent 3: `earth-gold` (`#a16207`)
-- Link: default `stone-600` -> hover `earth-terra`
+
+### Palette (2026-05-10 一新)
+配色の "色数を減らす" 方向に整理。装飾用の暖色（terra / gold）は廃止し、無彩色 stone を基調に据える。
+
+| Role | Token | Hex | Usage |
+|---|---|---|---|
+| Canvas | `stone-50` | `#fafaf9` | デフォルト背景 |
+| Surface | `stone-100` | `#f5f5f4` | セクション差し替え |
+| Dark canvas | `stone-900` | `#1c1917` | ダーク帯（章ブレイク）/ 主 CTA 面 |
+| Text primary | `stone-900` | `#1c1917` | 本文 / 見出し |
+| Text secondary | `stone-700` | `#44403c` | 副見出し / リード |
+| Text tertiary | `stone-500` | `#78716c` | キャプション |
+| Border | `stone-200` / `stone-300` / `stone-400` | — | 罫線 |
+| **Brand accent** | `earth-sage` | `#4d7c5f` | **唯一の有彩色**。Chapter 見出しのアイブロウのみ使用 |
+
+### 使わなくなった色（将来も使わない）
+- `earth-terra` (`#b45309`) — クラフト寄りでブランドに合わなかったため廃止
+- `earth-gold` (`#a16207`) — 同上、廃止
+
+> 既存実装には残っているが、新規追加はしない。リファクタ時に随時剥離。
+
+### リンク・ホバー方針
+- 通常の文字リンク: `stone-700` → hover `stone-900`
+- アンダーライン使用 OK（hover 時のみ表示）
+- 色のシフトでホバーを表現しない（濃度・下線・微小スケールで表す）
+
+## 2-bis. Buttons / CTA System
+
+3 種類だけに統一する。新規ボタンを増やす場合はまず既存に当てはめ、足りなければここを更新する。
+
+### Primary（最重要 CTA）
+- bg: `stone-900`
+- text: `stone-50`
+- hover: `bg-stone-700`
+- 例: メインの問い合わせボタン、各ページの主導線
+
+### Secondary（罫線型）
+- bg: 透明（または `stone-50`）
+- border: `stone-400`
+- text: `stone-700`
+- hover: `border-stone-900` + `text-stone-900`
+- 例: SNS、副 CTA、Media Kit などの補助導線
+
+### Ghost / Inline（文字リンク）
+- text: `stone-700`
+- hover: `text-stone-900` + `underline`
+- 例: パンくず、補助テキストリンク
+
+### 共通ルール
+- すべて `focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2` を必須
+- 角丸なし（直角を維持、編集物トーン）
+- アニメーションは `transition-colors` のみ（色変化以外しない）
+- アイコン併用時は `gap-2` 〜 `gap-3`
+- 文言と遷移先の整合は [04-navigation-and-structure-spec.md](04-navigation-and-structure-spec.md) §5 を参照
 
 ## 3. Typography
 - Heading font: `Zen Old Mincho` (fallback: `Shippori Mincho`, `Yu Mincho`, serif)


### PR DESCRIPTION
## Summary
ご指摘の「ボタンの色もホバーも統一感がない / オレンジが残っている」を根本対応。デザインカラーを **明文で定義** し、コードからオレンジ系を排除。

### 新パレット（[02-design-guide.md](../blob/main/docs/02-design-guide.md) §2 / §2-bis）
- 基調: stone scale のみ
- 唯一の有彩色: \`earth-sage\` (緑) — **Chapter NN — ...** のアイブロウだけに使用
- \`earth-terra\` (オレンジ) と \`earth-gold\` (マスタード) は **active コンポーネントから完全撤去**
- ボタン体系を 3 種類（Primary / Secondary / Ghost）に固定

### Code changes
| 場所 | Before | After |
|---|---|---|
| Concept "INTRODUCTION" | text-earth-gold | text-earth-sage |
| Concept 罫 | bg-earth-gold/60 | bg-stone-500 |
| Concept ドット | bg-earth-gold | bg-stone-400 |
| Profile "300+ / 10yr" | text-earth-gold | text-stone-900 |
| Works "300+ / 5 / 30+" | text-earth-gold | text-stone-900 |
| Works CTA hover | hover:bg-earth-terra | hover:bg-stone-700 |
| 全 hover:bg-earth-terra | terra | stone-700 |
| 全 hover:border-earth-terra | terra | stone-900 |
| 全 hover:text-earth-terra | terra | stone-900 |
| 全 focus-visible:ring-earth-terra | terra | stone-900 |
| Filter chip active bg | terra | stone-900 |
| Sticky nav active | terra/10 + terra | stone-100 + stone-900 |
| 各種 decorative text-earth-terra | terra | stone-700 |
| Hero 暖色 radial accent | terra rgba | ink rgba |

### Untouched (意図的)
- \`earth-sage\` の Chapter アイブロウ（唯一の accent として残す）
- 未使用コンポーネント（FeaturedJournal / FeaturedPage / JournalPage / LatestJournal）の terra — App.tsx で import されていない dead code

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で全ページに オレンジ / マスタード が出ていないこと
- [ ] preview で全ボタンの hover が「色変わり」ではなく「濃度変化」になっていること
- [ ] preview で フィルタの active 表示が黒面（stone-900）になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)