### PR TITLE
chore drop grayscale filter on profile portrait

### DIFF
--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -27,7 +27,7 @@ const Profile: React.FC = () => {
               <img
                 src="/profile-portrait.jpg"
                 alt="ぺんぺんすけ ポートレート"
-                className="h-full w-full object-cover grayscale transition-all duration-700 ease-out hover:grayscale-0"
+                className="h-full w-full object-cover"
                 loading="lazy"
                 decoding="async"
               />


### PR DESCRIPTION
## Summary
\`components/Profile.tsx\` のポートレート img から \`grayscale\` / \`hover:grayscale-0\` / トランジションを削除。イラストなので最初からそのまま表示する。

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview でポートレートが最初からカラー（イラスト本来の色）で表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)