### PR TITLE
feat unify CTA button styles via shared lib

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ArrowUpRight, Instagram } from 'lucide-react';
+import { buttonPrimary, buttonSecondary } from '../lib/buttonStyles';
 
 const Contact: React.FC = () => {
   return (
@@ -26,22 +27,22 @@ const Contact: React.FC = () => {
           <div className="space-y-3">
             <a
               href="mailto:contact@sensoria.example"
-              className="group flex items-center justify-between gap-4 bg-stone-900 px-6 py-5 text-sm tracking-widest text-stone-50 transition-colors hover:bg-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
+              className={`${buttonPrimary} w-full`}
             >
-              <span className="uppercase">メールで連絡する</span>
-              <ArrowUpRight className="h-5 w-5 transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5" aria-hidden="true" />
+              メールで連絡する
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>
             <a
               href="https://www.instagram.com/rika05181/"
               target="_blank"
               rel="noopener noreferrer"
-              className="group flex items-center justify-between gap-4 border border-stone-400 px-6 py-5 text-sm tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
+              className={`${buttonSecondary} w-full`}
             >
-              <span className="uppercase inline-flex items-center gap-3">
+              <span className="inline-flex items-center gap-3">
                 <Instagram className="h-4 w-4" aria-hidden="true" />
                 Instagram で見る
               </span>
-              <ArrowUpRight className="h-5 w-5" aria-hidden="true" />
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>
           </div>
         </div>

--- a/components/MediaKitPage.tsx
+++ b/components/MediaKitPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowUpRight, BriefcaseBusiness, Download, Mail, MessageSquareText, Newspaper, Sparkles } from 'lucide-react';
 import Header from './Header';
+import { buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
 
 const profileFacts = [
   ['Theme', '五感美容 / 旅 / アート / 暮らし'],
@@ -104,7 +105,7 @@ const MediaKitPage: React.FC = () => {
               <p className="mt-6 text-sm leading-loose text-stone-300">
                 記事制作、体験取材、音声企画、アンバサダー相談など、媒体や目的に合わせて整理できます。
               </p>
-              <a href="#contact" className="mt-8 inline-flex items-center gap-2 border border-stone-500 px-4 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:text-stone-900">
+              <a href="#contact" className={`mt-8 ${buttonSecondaryOnDark}`}>
                 Contact
                 <Mail className="h-4 w-4" aria-hidden="true" />
               </a>
@@ -121,9 +122,12 @@ const MediaKitPage: React.FC = () => {
                 #15 の根拠確認が進んだら、媒体掲載履歴や専門領域別実績をこのページにも反映します。
               </p>
             </div>
-            <a href="#/works" className="inline-flex items-center justify-center gap-2 border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
-              <Download className="h-4 w-4" aria-hidden="true" />
-              Works
+            <a href="#/works" className={buttonSecondary}>
+              <span className="inline-flex items-center gap-3">
+                <Download className="h-4 w-4" aria-hidden="true" />
+                Works
+              </span>
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>
           </div>
         </section>

--- a/components/Works.tsx
+++ b/components/Works.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ArrowUpRight } from 'lucide-react';
+import { buttonPrimary } from '../lib/buttonStyles';
 
 type SummaryItem = {
   value: string;
@@ -32,10 +33,7 @@ const Works: React.FC = () => {
               執筆、取材、音声配信、外部掲載までの活動を専用ページに集約しています。
               媒体ごとのトーンを大切にしながら、体験の感触を残す記録を続けてきました。
             </p>
-            <a
-              href="#/works"
-              className="mt-10 inline-flex items-center gap-3 bg-stone-900 px-6 py-4 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:bg-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
-            >
+            <a href="#/works" className={`mt-10 ${buttonPrimary}`}>
               実績ページを見る
               <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowUpRight, BookOpenText, Headphones, Landmark, Newspaper, Sparkles } from 'lucide-react';
 import Header from './Header';
+import { buttonPrimary, buttonPrimaryOnDark, buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
 import { WorksLinkItem } from '../types';
 import {
   achievementLinkCategories,
@@ -132,14 +133,17 @@ const WorksPage: React.FC = () => {
                 美容、旅、アート、文化、音声配信まで。媒体ごとの文脈に寄り添いながら、体験を言葉と導線に整えてきた活動をまとめています。
               </p>
               <div className="mt-8 flex flex-wrap gap-3">
-                <a href="#featured-works" className="border border-stone-800 bg-stone-800 px-5 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:bg-stone-700">
+                <a href="#featured-works" className={buttonPrimary}>
                   Featured
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>
-                <a href="#link-library" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
+                <a href="#link-library" className={buttonSecondary}>
                   Link Library
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>
-                <a href="#/media-kit" className="border border-stone-300 px-5 py-3 text-xs uppercase tracking-widest text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900">
+                <a href="#/media-kit" className={buttonSecondary}>
                   Media Kit
+                  <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>
               </div>
             </div>
@@ -441,17 +445,11 @@ const WorksPage: React.FC = () => {
                 </p>
               </div>
               <div className="flex flex-col gap-3 sm:flex-row">
-                <a
-                  href="#contact"
-                  className="inline-flex items-center justify-center gap-2 bg-stone-50 px-6 py-3 text-xs uppercase tracking-widest text-stone-900 transition-colors hover:bg-stone-700 hover:text-stone-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
-                >
+                <a href="#contact" className={buttonPrimaryOnDark}>
                   Contact
                   <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>
-                <a
-                  href="#/media-kit"
-                  className="inline-flex items-center justify-center gap-2 border border-stone-500 px-6 py-3 text-xs uppercase tracking-widest text-stone-50 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2 focus-visible:ring-offset-stone-900"
-                >
+                <a href="#/media-kit" className={buttonSecondaryOnDark}>
                   Media Kit
                   <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
                 </a>

--- a/lib/buttonStyles.ts
+++ b/lib/buttonStyles.ts
@@ -1,0 +1,22 @@
+// Button class strings — single source of truth.
+// See docs/02-design-guide.md §2-bis for the rationale (3-tier system,
+// solid / bordered / dark variants).
+
+const base =
+  'inline-flex items-center justify-between gap-3 px-6 py-4 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2';
+
+// Primary: solid ink button on a light background.
+export const buttonPrimary =
+  `${base} bg-stone-900 text-stone-50 hover:bg-stone-700 focus-visible:ring-stone-900`;
+
+// Secondary: bordered button on a light background.
+export const buttonSecondary =
+  `${base} border border-stone-400 text-stone-700 hover:border-stone-900 hover:text-stone-900 focus-visible:ring-stone-900`;
+
+// Primary on dark canvas (e.g. dark closing band): inverted to light fill.
+export const buttonPrimaryOnDark =
+  `${base} bg-stone-50 text-stone-900 hover:bg-stone-200 focus-visible:ring-stone-50 focus-visible:ring-offset-stone-900`;
+
+// Secondary on dark canvas: bordered, light text.
+export const buttonSecondaryOnDark =
+  `${base} border border-stone-500 text-stone-50 hover:border-stone-50 focus-visible:ring-stone-50 focus-visible:ring-offset-stone-900`;


### PR DESCRIPTION
## Summary
ボタンの padding / 文字サイズ / gap / アイコン位置 がバラバラだった件を、構造レベルで統一。

### 戦略
\`lib/buttonStyles.ts\` に 4 バリアントの className を定数として置き、全 CTA 側で参照する。
- \`buttonPrimary\` (solid stone-900)
- \`buttonSecondary\` (bordered)
- \`buttonPrimaryOnDark\` (light fill on dark canvas)
- \`buttonSecondaryOnDark\` (light bordered on dark canvas)

すべて \`px-6 py-4 text-xs gap-3 inline-flex items-center justify-between\` で揃う。focus ring + offset も共通。

### 監査結果
| 場所 | Before | After |
|---|---|---|
| Home Works CTA | py-4 text-xs | buttonPrimary |
| Contact mail | py-5 text-sm（大きめ outlier） | buttonPrimary |
| Contact Instagram | py-5 text-sm border | buttonSecondary |
| WorksPage Hero chips | py-3 text-xs（小さめ outlier、矢印なし） | buttonPrimary / Secondary（矢印追加） |
| WorksPage 末尾 Contact | py-3 + 独自 inverted | buttonPrimaryOnDark |
| WorksPage 末尾 Media Kit | py-3 border-stone-500 | buttonSecondaryOnDark |
| MediaKit Hero Contact | py-3 ad hoc | buttonSecondaryOnDark |
| MediaKit Assets Works | py-3 ad hoc | buttonSecondary（先頭 icon + 末尾 arrow） |

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で全 CTA が同じ高さ・文字サイズ・gap で並ぶこと
- [ ] preview でホバーが「色変化なしの濃度変化」で揃うこと
- [ ] スマホでも横幅が揃うこと

## Note
- フィルタチップ / sticky nav pill / ページ内アンカーチップ等は "ボタン" ではなく "選択 UI" として別物扱い、本 PR では触らない
- 今後も新規 CTA は必ず \`lib/buttonStyles.ts\` から参照する。インラインで bg-stone-900 ... を書かない

🤖 Generated with [Claude Code](https://claude.com/claude-code)