### PR TITLE
chore unify contact buttons to same secondary style

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { ArrowUpRight, Instagram } from 'lucide-react';
-import { buttonPrimary, buttonSecondary } from '../lib/buttonStyles';
+import { ArrowUpRight, Instagram, Mail } from 'lucide-react';
+import { buttonSecondary } from '../lib/buttonStyles';
 
 const Contact: React.FC = () => {
   return (
@@ -27,9 +27,12 @@ const Contact: React.FC = () => {
           <div className="space-y-3">
             <a
               href="mailto:contact@sensoria.example"
-              className={`${buttonPrimary} w-full`}
+              className={`${buttonSecondary} w-full`}
             >
-              メールで連絡する
+              <span className="inline-flex items-center gap-3">
+                <Mail className="h-4 w-4" aria-hidden="true" />
+                メールで連絡する
+              </span>
               <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>
             <a


### PR DESCRIPTION
## Summary
Contact セクションのメール / Instagram を **両方 Secondary（罫線型）に揃える**。

### 変更点
- メール: Primary (solid stone-900) → Secondary (bordered)
- メールに Mail アイコンを左に追加（Instagram と同じ構成）
- 並び順は維持（メールが上）

### Why
Pattern D（Quiet Luxe）に倣えば、エディトリアル系 Web は同セクション内の CTA を同じ重みで揃えるのが王道。優先度は形ではなく "並び順" で示す。

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で 2 つのボタンが完全に同じ形になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)