### PR TITLE
feat unify card/chip/divider surface styles

### DIFF
--- a/components/Concept.tsx
+++ b/components/Concept.tsx
@@ -30,9 +30,7 @@ const Concept: React.FC = () => {
           </p>
         </div>
 
-        <div className="mt-16 flex justify-center">
-          <div className="h-2 w-2 rounded-full bg-stone-400" />
-        </div>
+        <div className="mt-16 mx-auto h-[1px] w-16 bg-stone-500" />
       </div>
     </section>
   );

--- a/components/MediaKitPage.tsx
+++ b/components/MediaKitPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ArrowUpRight, BriefcaseBusiness, Download, Mail, MessageSquareText, Newspaper, Sparkles } from 'lucide-react';
 import Header from './Header';
 import { buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
+import { card, cardDark, cardFlat } from '../lib/surfaces';
 
 const profileFacts = [
   ['Theme', '五感美容 / 旅 / アート / 暮らし'],
@@ -43,7 +44,7 @@ const MediaKitPage: React.FC = () => {
                 プロフィール、得意テーマ、掲載媒体、問い合わせ導線をまとめた簡易メディアキットです。取材、寄稿、アンバサダー、音声企画などの検討に使えます。
               </p>
             </div>
-            <div className="border border-stone-200 bg-stone-50/90 p-6 backdrop-blur">
+            <div className={card}>
               <Sparkles className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <p className="mt-6 font-serif text-2xl leading-relaxed text-stone-900">
                 五感を切り口に、体験と読者の暮らしをつなぐ発信者。
@@ -64,7 +65,7 @@ const MediaKitPage: React.FC = () => {
             </div>
             <div className="grid grid-cols-1 gap-px overflow-hidden border border-stone-200 bg-stone-200 md:grid-cols-3">
               {profileFacts.map(([label, value]) => (
-                <div key={label} className="bg-stone-50 p-6">
+                <div key={label} className={cardFlat}>
                   <span className="text-xs uppercase tracking-widest text-stone-500">{label}</span>
                   <p className="mt-4 text-sm leading-loose text-stone-700">{value}</p>
                 </div>
@@ -75,7 +76,7 @@ const MediaKitPage: React.FC = () => {
 
         <section className="border-y border-stone-200 bg-stone-100/70">
           <div className="mx-auto grid max-w-screen-xl grid-cols-1 gap-8 px-6 py-16 md:grid-cols-3 md:py-20">
-            <article className="bg-stone-50 p-6">
+            <article className={cardFlat}>
               <MessageSquareText className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl text-stone-900">話せるテーマ</h3>
               <ul className="mt-6 space-y-4">
@@ -87,7 +88,7 @@ const MediaKitPage: React.FC = () => {
               </ul>
             </article>
 
-            <article className="bg-stone-50 p-6">
+            <article className={cardFlat}>
               <Newspaper className="h-6 w-6 text-stone-600" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl text-stone-900">掲載・発信先</h3>
               <div className="mt-6 flex flex-wrap gap-2">
@@ -99,7 +100,7 @@ const MediaKitPage: React.FC = () => {
               </div>
             </article>
 
-            <article className="bg-stone-900 p-6 text-stone-50">
+            <article className={cardDark}>
               <BriefcaseBusiness className="h-6 w-6 text-stone-900" aria-hidden="true" />
               <h3 className="mt-6 font-serif text-2xl">依頼の相談</h3>
               <p className="mt-6 text-sm leading-loose text-stone-300">
@@ -114,7 +115,7 @@ const MediaKitPage: React.FC = () => {
         </section>
 
         <section className="mx-auto max-w-screen-xl px-6 py-16 md:py-20">
-          <div className="grid grid-cols-1 gap-8 border border-stone-200 bg-stone-50 p-6 md:grid-cols-[1fr_auto] md:items-center md:p-8">
+          <div className={`${card} grid grid-cols-1 gap-8 md:grid-cols-[1fr_auto] md:items-center`}>
             <div>
               <span className="block text-xs uppercase tracking-[0.3em] text-earth-sage">Assets</span>
               <h3 className="mt-3 font-serif text-3xl text-stone-900">素材と実績は段階的に整備中</h3>

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -23,7 +23,7 @@ const Profile: React.FC = () => {
         {/* Asymmetric: small portrait left, copy right (lg only) */}
         <div className="mt-20 grid grid-cols-1 gap-12 lg:grid-cols-[240px_1fr] lg:gap-16">
           <div className="mx-auto lg:mx-0 w-full max-w-[240px]">
-            <div className="relative aspect-[3/4] w-full">
+            <div className="aspect-[3/4] w-full">
               <img
                 src="/profile-portrait.jpg"
                 alt="ぺんぺんすけ ポートレート"
@@ -31,7 +31,6 @@ const Profile: React.FC = () => {
                 loading="lazy"
                 decoding="async"
               />
-              <div aria-hidden="true" className="absolute -bottom-3 -right-3 h-full w-full border border-stone-300 -z-10" />
             </div>
             <div className="mt-6 text-center text-xs tracking-widest text-stone-400 uppercase lg:text-left">
               Writer / Editor

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -2,6 +2,18 @@ import React from 'react';
 import { ArrowUpRight, BookOpenText, Headphones, Landmark, Newspaper, Sparkles } from 'lucide-react';
 import Header from './Header';
 import { buttonPrimary, buttonPrimaryOnDark, buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
+import {
+  card,
+  cardCompactInteractive,
+  cardDashed,
+  cardDashedInteractive,
+  cardFlat,
+  cardFrameInteractive,
+  chip,
+  chipActive,
+  pill,
+  pillActive,
+} from '../lib/surfaces';
 import { WorksLinkItem } from '../types';
 import {
   achievementLinkCategories,
@@ -150,7 +162,7 @@ const WorksPage: React.FC = () => {
 
             <div className="relative z-10 grid grid-cols-1 gap-3">
               {worksMetrics.map((metric) => (
-                <div key={metric.label} className="border border-stone-200 bg-stone-50/90 p-5 backdrop-blur">
+                <div key={metric.label} className={card}>
                   <span className="block font-serif text-4xl text-stone-900">{metric.value}</span>
                   <span className="mt-2 block text-xs uppercase tracking-widest text-stone-500">{metric.label}</span>
                   <p className="mt-3 text-sm leading-relaxed text-stone-600">{metric.note}</p>
@@ -194,7 +206,7 @@ const WorksPage: React.FC = () => {
                   href={work.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="group flex flex-col overflow-hidden border border-stone-200 bg-stone-50 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
+                  className={`${cardFrameInteractive} group flex flex-col overflow-hidden`}
                 >
                   <div className="relative aspect-[4/5] overflow-hidden bg-gradient-to-br from-stone-100 via-stone-200 to-stone-300">
                     {work.keyVisual ? (
@@ -255,7 +267,7 @@ const WorksPage: React.FC = () => {
               {worksDetailItems.map((item, index) => {
                 const Icon = categoryIcons[index] ?? Sparkles;
                 return (
-                  <article key={item.title} className="bg-stone-50 p-5 md:p-6">
+                  <article key={item.title} className={cardFlat}>
                     <Icon className="h-5 w-5 text-stone-600" aria-hidden="true" />
                     <span className="mt-5 block text-xs uppercase tracking-widest text-stone-500">{item.category}</span>
                     <h4 className="mt-3 font-serif text-lg leading-relaxed text-stone-900">{item.title}</h4>
@@ -302,11 +314,7 @@ const WorksPage: React.FC = () => {
                     type="button"
                     onClick={() => toggleTopic(topic)}
                     aria-pressed={isActive}
-                    className={
-                      isActive
-                        ? 'border border-stone-900 bg-stone-900 px-3 py-1.5 text-xs text-stone-50 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900'
-                        : 'border border-stone-300 bg-stone-50 px-3 py-1.5 text-xs text-stone-700 transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900'
-                    }
+                    className={isActive ? chipActive : chip}
                   >
                     {topic}
                   </button>
@@ -326,12 +334,7 @@ const WorksPage: React.FC = () => {
                 <a
                   key={category.name}
                   href={`#works-${category.slug}`}
-                  className={
-                    'flex-none border px-4 py-2 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 ' +
-                    (isActive
-                      ? 'border-stone-900 bg-stone-100 text-stone-900'
-                      : 'border-stone-200 bg-stone-50 text-stone-700 hover:border-stone-700 hover:text-stone-900')
-                  }
+                  className={`${isActive ? pillActive : pill} flex-none`}
                 >
                   <span className="font-serif text-sm">{category.name}</span>
                   <span className="ml-2 text-[10px] text-stone-500">{category.items.length}</span>
@@ -341,7 +344,7 @@ const WorksPage: React.FC = () => {
           </nav>
 
           {noResults ? (
-            <div className="border border-dashed border-stone-300 bg-stone-50 px-6 py-12 text-center">
+            <div className={`${cardDashed} text-center`}>
               <p className="font-serif text-lg text-stone-700">該当する掲載が見つかりませんでした。</p>
               <p className="mt-3 text-sm leading-loose text-stone-500">フィルタを解除すると、すべての掲載リンクが表示されます。</p>
               <button
@@ -389,7 +392,7 @@ const WorksPage: React.FC = () => {
                           href={link.url}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="work-link group border border-stone-200 bg-stone-50 px-5 py-4 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900"
+                          className={`work-link ${cardCompactInteractive} group`}
                         >
                           <p className="work-title text-sm leading-relaxed text-stone-800 md:text-base">{link.title}</p>
                           {metaParts.length > 0 && (
@@ -412,7 +415,7 @@ const WorksPage: React.FC = () => {
                         href={category.viewAllUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="group flex flex-col justify-between border border-dashed border-stone-300 bg-stone-50 px-5 py-4 transition-colors hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 md:col-span-2"
+                        className={`${cardDashedInteractive} group flex flex-col justify-between md:col-span-2`}
                       >
                         <p className="font-serif text-base leading-relaxed text-stone-800 md:text-lg">
                           {category.viewAllLabel ?? 'すべて見る'}

--- a/lib/surfaces.ts
+++ b/lib/surfaces.ts
@@ -1,0 +1,58 @@
+// Surface class strings — single source of truth for cards, chips, dividers.
+// Pair with lib/buttonStyles.ts for CTA buttons.
+// See docs/02-design-guide.md for the underlying tokens.
+
+// ---------- Cards ----------
+const cardBordered = 'border border-stone-200 bg-stone-50 transition-colors';
+const cardInteractiveExt =
+  'hover:border-stone-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900';
+
+// Standard p-6 bordered card — Featured copy area, MediaKit hero accent, Hero metrics.
+export const card = `${cardBordered} p-6`;
+export const cardInteractive = `${cardBordered} ${cardInteractiveExt} p-6`;
+
+// Compact px-5 py-4 bordered card — Link cards in dense grids.
+export const cardCompact = `${cardBordered} px-5 py-4`;
+export const cardCompactInteractive = `${cardBordered} ${cardInteractiveExt} px-5 py-4`;
+
+// Bordered frame with no padding — when children handle their own padding
+// (e.g. image header + p-6 content below).
+export const cardFrame = `${cardBordered}`;
+export const cardFrameInteractive = `${cardBordered} ${cardInteractiveExt}`;
+
+// Flat card with no border — lives inside a grid that uses gap-px on a stone-200 parent.
+export const cardFlat = 'bg-stone-50 p-6 transition-colors';
+
+// Dashed placeholder / empty state / "view all" sentinel.
+export const cardDashed =
+  'border border-dashed border-stone-300 bg-stone-50 p-6 transition-colors';
+
+export const cardDashedInteractive =
+  `border border-dashed border-stone-300 bg-stone-50 p-6 transition-colors ${cardInteractiveExt}`;
+
+// Dark inverted card (for dark bands).
+export const cardDark = 'bg-stone-900 text-stone-50 p-6 transition-colors';
+
+// ---------- Chips (small tag/filter rectangles) ----------
+const chipBase =
+  'inline-flex items-center px-3 py-1.5 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900';
+
+export const chip =
+  `${chipBase} border border-stone-300 bg-stone-50 text-stone-700 hover:border-stone-700 hover:text-stone-900`;
+
+export const chipActive =
+  `${chipBase} border border-stone-900 bg-stone-900 text-stone-50`;
+
+// ---------- Pills (slightly larger chips for sticky nav) ----------
+const pillBase =
+  'inline-flex items-center px-4 py-2 text-xs uppercase tracking-widest transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900';
+
+export const pill =
+  `${pillBase} border border-stone-200 bg-stone-50 text-stone-700 hover:border-stone-700 hover:text-stone-900`;
+
+export const pillActive =
+  `${pillBase} border border-stone-900 bg-stone-100 text-stone-900`;
+
+// ---------- Dividers ----------
+export const ruleHorizontal = 'h-[1px] bg-stone-300';
+export const ruleVertical = 'w-[1px] bg-stone-300';


### PR DESCRIPTION
## Summary
ボタン以外の "四角"（カード / チップ / ピル / 罫線）が場所ごとに微妙にずれていた件を、\`lib/surfaces.ts\` への集約で一掃。

### 揃えた寸法
- カード padding: 5 種混在 → \`p-6\` / \`px-5 py-4\` / "no padding" の 3 種に固定
- チップサイズ: 5 種混在 → \`px-3 py-1.5\` (chip) / \`px-4 py-2\` (pill) の 2 種に固定
- 装飾要素: \`rounded-full\` ドット → 横罫 (1px) に統一、Profile ポートレート裏面ボーダーを削除

### 主な置換
| 場所 | Before | After |
|---|---|---|
| WorksPage Hero メトリクス | p-5 + bg/90 + blur | \`card\` |
| WorksPage Featured 外枠 | ad-hoc | \`cardFrameInteractive\` |
| WorksPage Expertise タイル | ad-hoc 5/6 | \`cardFlat\` |
| WorksPage Link カード | px-5 py-4 ad-hoc | \`cardCompactInteractive\` |
| WorksPage View-all カード | dashed px-5 py-4 | \`cardDashedInteractive\` |
| WorksPage Empty 状態 | dashed px-6 py-12 | \`cardDashed\` |
| WorksPage フィルタチップ | inline | \`chip\` / \`chipActive\` |
| WorksPage Sticky nav | inline | \`pill\` / \`pillActive\` |
| MediaKit Hero / Assets | p-6 ad-hoc | \`card\` |
| MediaKit Profile / Topics / Press | p-6 ad-hoc | \`cardFlat\` |
| MediaKit 依頼 dark | bg-stone-900 p-6 | \`cardDark\` |
| Profile portrait | -bottom-3 -right-3 ボーダー | 削除 |
| Concept dot | rounded-full | h-[1px] w-16 罫 |

### 残した個別判断
- Press mentions の媒体名タグは uppercase / tracking-widest が日本語に不自然なため inline 維持（将来 \`tag\` バリアント候補）

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で全カードの padding が同じ高さ感で揃うこと
- [ ] preview でフィルタチップ / sticky nav の寸法が揃うこと
- [ ] preview で Profile ポートレートの背景四角が消えていること
- [ ] preview で Concept セクション末尾が罫線になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)