### PR TITLE
feat editorial layout pass (hero / portrait / expertise / works hero / footer)

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -6,6 +6,10 @@ const Footer: React.FC = () => {
     <footer className="bg-stone-900 text-stone-400 py-16 md:py-24">
       <div className="max-w-screen-xl mx-auto px-6 flex flex-col items-center">
         
+        <span className="mb-4 block text-[10px] uppercase tracking-[0.4em] text-stone-500">
+          Vol. 01 — 2026
+        </span>
+
         <a href="#top" className="text-3xl font-serif tracking-widest text-stone-200 mb-8 hover:opacity-80 transition-opacity">
           Sensoria
         </a>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const Hero: React.FC = () => {
   return (
-    <section className="relative w-full min-h-screen flex items-center justify-center overflow-hidden bg-gradient-to-b from-stone-100 via-stone-50 to-stone-50">
+    <section className="relative w-full min-h-[80vh] flex items-center justify-center overflow-hidden bg-gradient-to-b from-stone-100 via-stone-50 to-stone-50">
       {/* Decorative serif watermark — museum-catalog feel */}
       <span
         aria-hidden="true"
@@ -40,11 +40,11 @@ const Hero: React.FC = () => {
       {/* Bottom fade for seamless transition into next section */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-stone-50"
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-b from-transparent to-stone-50"
       />
 
       {/* Content */}
-      <div className="relative z-10 max-w-screen-md mx-auto px-6 text-center pt-20">
+      <div className="relative z-10 max-w-screen-md mx-auto px-6 text-center pt-24">
         <p
           className="text-earth-sage font-medium tracking-[0.3em] text-sm md:text-base mb-6 uppercase fade-in-up"
           style={{ animationDelay: '0.2s' }}
@@ -58,21 +58,29 @@ const Hero: React.FC = () => {
         ></div>
 
         <p
-          className="text-stone-800 text-lg md:text-xl font-serif leading-relaxed tracking-wider fade-in-up"
+          className="text-stone-900 text-2xl md:text-5xl font-serif leading-snug tracking-wider fade-in-up"
           style={{ animationDelay: '0.8s' }}
         >
           アート、旅、美容で紡ぐ
-          <br className="md:hidden" />
+          <br />
           「五感美容」の記録。
         </p>
 
         <p
-          className="mt-8 text-sm text-stone-600 tracking-widest fade-in-up"
+          className="mt-10 text-sm md:text-base text-stone-600 tracking-widest leading-loose fade-in-up"
           style={{ animationDelay: '1s' }}
         >
           日経Webでの300本の連載を経てたどり着いた、
           <br className="md:hidden" />
           心地よい暮らしの美学。
+        </p>
+
+        {/* Mobile decoration (small issue marker) — only when gutter is hidden */}
+        <p
+          className="mt-12 text-[10px] uppercase tracking-[0.4em] text-stone-500 fade-in-up lg:hidden"
+          style={{ animationDelay: '1.2s' }}
+        >
+          Vol. 01 — 2026
         </p>
       </div>
     </section>

--- a/components/Profile.tsx
+++ b/components/Profile.tsx
@@ -20,9 +20,9 @@ const Profile: React.FC = () => {
           <footer className="mt-8 text-sm tracking-widest text-stone-500 uppercase">— Editorial Stance</footer>
         </blockquote>
 
-        {/* Asymmetric: small portrait left, copy right (lg only) */}
-        <div className="mt-20 grid grid-cols-1 gap-12 lg:grid-cols-[240px_1fr] lg:gap-16">
-          <div className="mx-auto lg:mx-0 w-full max-w-[240px]">
+        {/* Asymmetric: portrait left, copy right (lg only) */}
+        <div className="mt-20 grid grid-cols-1 gap-12 lg:grid-cols-[320px_1fr] lg:gap-20">
+          <div className="mx-auto lg:mx-0 w-full max-w-[320px]">
             <div className="aspect-[3/4] w-full">
               <img
                 src="/profile-portrait.jpg"

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -3,7 +3,6 @@ import { ArrowUpRight, BookOpenText, Headphones, Landmark, Newspaper, Sparkles }
 import Header from './Header';
 import { buttonPrimary, buttonPrimaryOnDark, buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
 import {
-  card,
   cardCompactInteractive,
   cardDashed,
   cardDashedInteractive,
@@ -19,7 +18,6 @@ import {
   achievementLinkCategories,
   featuredWorks,
   worksDetailItems,
-  worksMetrics,
 } from '../data/works';
 
 const getCta = (item: WorksLinkItem): WorksLinkItem['cta'] => {
@@ -160,15 +158,15 @@ const WorksPage: React.FC = () => {
               </div>
             </div>
 
-            <div className="relative z-10 grid grid-cols-1 gap-3">
-              {worksMetrics.map((metric) => (
-                <div key={metric.label} className={card}>
-                  <span className="block font-serif text-4xl text-stone-900">{metric.value}</span>
-                  <span className="mt-2 block text-xs uppercase tracking-widest text-stone-500">{metric.label}</span>
-                  <p className="mt-3 text-sm leading-relaxed text-stone-600">{metric.note}</p>
-                </div>
-              ))}
-            </div>
+            <aside className="relative z-10 border-l-2 border-stone-300 pl-8">
+              <span className="block text-[11px] uppercase tracking-[0.4em] text-stone-500">Issue 01 — 2026</span>
+              <p className="mt-8 font-serif text-2xl leading-loose text-stone-900 md:text-3xl">
+                媒体ごとの空気を読み、<br />生活者の感覚に翻訳する。
+              </p>
+              <span className="mt-8 block text-xs uppercase tracking-widest text-stone-500">
+                Editorial Portfolio
+              </span>
+            </aside>
           </div>
         </section>
 
@@ -263,7 +261,7 @@ const WorksPage: React.FC = () => {
               </p>
             </div>
 
-            <div className="grid grid-cols-1 gap-px overflow-hidden border border-stone-200 bg-stone-200 md:grid-cols-2 lg:grid-cols-5">
+            <div className="grid grid-cols-1 gap-px overflow-hidden border border-stone-200 bg-stone-200 md:grid-cols-2 lg:grid-cols-3">
               {worksDetailItems.map((item, index) => {
                 const Icon = categoryIcons[index] ?? Sparkles;
                 return (


### PR DESCRIPTION
## Summary
Fashion magazine 系（KINFOLK / T Magazine / GINZA / Hanako / MR PORTER）と比較した時のレイアウト的違和感を一括で修正。

### 変更点
| 場所 | Before | After |
|---|---|---|
| Home Hero 高さ | \`min-h-screen\` | \`min-h-[80vh]\` |
| Home Hero メインコピー | text-lg md:text-xl | text-2xl md:text-5xl |
| Home Hero モバイル装飾 | なし | "Vol. 01 — 2026" マーカー追加 |
| Profile ポートレート | 240px | 320px（lg）+ grid column 拡張 |
| WorksPage Hero 右列 | 3 枚のメトリクスカード（ダッシュボード感） | 罫線 + Issue 01 / 引用 / Editorial Portfolio ラベル |
| WorksPage Expertise grid | lg:grid-cols-5（密集） | lg:grid-cols-3（呼吸） |
| Footer | ロゴ + nav + SNS | 先頭に "Vol. 01 — 2026" マーカー追加 |

### 見送った項目（リスク大のため別 PR 候補）
- Featured 3 枚のアシンメトリ化（aspect-ratio との競合があり、構造変更が必要）
- コンテナ幅の出し入れ（Concept narrow / Featured wide 等）
- Contact 引用 / 寄稿先チップの追加

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview で Home Hero がスクロール前に次セクションを少し見せること
- [ ] preview で Hero のメインコピーが大きく serif で出ること
- [ ] preview でモバイル Hero に "Vol. 01 — 2026" が表示されること
- [ ] preview で Profile ポートレートが大きくなり存在感が出ていること
- [ ] preview で WorksPage Hero 右列がメトリクスではなく引用ブロックになっていること
- [ ] preview で Expertise が 3 列に広がり読みやすくなっていること
- [ ] preview で Footer に "Vol. 01 — 2026" が出ていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)