### PR TITLE
feat round a: press chips / back-to-top / 404 / json-ld

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,22 +9,21 @@ import Footer from './components/Footer';
 import WorksPage from './components/WorksPage';
 import Issue15AuditPage from './components/Issue15AuditPage';
 import MediaKitPage from './components/MediaKitPage';
+import NotFoundPage from './components/NotFoundPage';
 
-const getRoute = (): 'home' | 'works' | 'issue15Audit' | 'mediaKit' => {
-  if (window.location.hash.startsWith('#/media-kit')) {
-    return 'mediaKit';
-  }
-  if (window.location.hash.startsWith('#/issue15-audit')) {
-    return 'issue15Audit';
-  }
-  if (window.location.hash.startsWith('#/works')) {
-    return 'works';
-  }
+type Route = 'home' | 'works' | 'issue15Audit' | 'mediaKit' | 'notFound';
+
+const getRoute = (): Route => {
+  const hash = window.location.hash;
+  if (hash.startsWith('#/media-kit')) return 'mediaKit';
+  if (hash.startsWith('#/issue15-audit')) return 'issue15Audit';
+  if (hash.startsWith('#/works')) return 'works';
+  if (hash.startsWith('#/')) return 'notFound';
   return 'home';
 };
 
 const App: React.FC = () => {
-  const [route, setRoute] = React.useState<'home' | 'works' | 'issue15Audit' | 'mediaKit'>(getRoute);
+  const [route, setRoute] = React.useState<Route>(getRoute);
 
   React.useEffect(() => {
     const handleHashChange = () => setRoute(getRoute());
@@ -57,6 +56,10 @@ const App: React.FC = () => {
 
   if (route === 'mediaKit') {
     return <MediaKitPage />;
+  }
+
+  if (route === 'notFound') {
+    return <NotFoundPage />;
   }
 
   return (

--- a/components/BackToTop.tsx
+++ b/components/BackToTop.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { ArrowUp } from 'lucide-react';
+
+const BackToTop: React.FC = () => {
+  const [visible, setVisible] = React.useState(false);
+
+  React.useEffect(() => {
+    const onScroll = () => setVisible(window.scrollY > 600);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const handleClick = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  if (!visible) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      aria-label="ページ上部へ戻る"
+      className="fixed bottom-6 right-6 z-40 inline-flex h-10 w-10 items-center justify-center border border-stone-400 bg-stone-50/90 text-stone-700 backdrop-blur transition-colors hover:border-stone-900 hover:text-stone-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-stone-900 focus-visible:ring-offset-2"
+    >
+      <ArrowUp className="h-4 w-4" aria-hidden="true" />
+    </button>
+  );
+};
+
+export default BackToTop;

--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ArrowUpRight, Instagram, Mail } from 'lucide-react';
 import { buttonSecondary } from '../lib/buttonStyles';
+import { pressMentions } from '../data/press';
 
 const Contact: React.FC = () => {
   return (
@@ -24,7 +25,22 @@ const Contact: React.FC = () => {
             </p>
           </div>
 
-          <div className="space-y-3">
+          <div className="space-y-6">
+            <div>
+              <span className="block text-[11px] uppercase tracking-[0.4em] text-stone-500">Press</span>
+              <ul className="mt-4 flex flex-wrap gap-x-3 gap-y-2 text-sm text-stone-700">
+                {pressMentions.map((name, i) => (
+                  <li key={name} className="inline-flex items-center">
+                    {name}
+                    {i < pressMentions.length - 1 && (
+                      <span aria-hidden="true" className="ml-3 text-stone-400">·</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="space-y-3">
             <a
               href="mailto:contact@sensoria.example"
               className={`${buttonSecondary} w-full`}
@@ -47,6 +63,7 @@ const Contact: React.FC = () => {
               </span>
               <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
             </a>
+            </div>
           </div>
         </div>
       </div>

--- a/components/MediaKitPage.tsx
+++ b/components/MediaKitPage.tsx
@@ -3,6 +3,7 @@ import { ArrowUpRight, BriefcaseBusiness, Download, Mail, MessageSquareText, New
 import Header from './Header';
 import { buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
 import { card, cardDark, cardFlat } from '../lib/surfaces';
+import { pressMentions } from '../data/press';
 
 const profileFacts = [
   ['Theme', '五感美容 / 旅 / アート / 暮らし'],
@@ -16,8 +17,6 @@ const topics = [
   '日常を整えるセルフケアと習慣',
   '媒体トーンに合わせた記事・企画づくり',
 ];
-
-const pressMentions = ['美的', '日経x woman', 'CREA', 'Hanako', 'シティリビング', 'Voicy'];
 
 const MediaKitPage: React.FC = () => {
   return (

--- a/components/NotFoundPage.tsx
+++ b/components/NotFoundPage.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { ArrowUpRight } from 'lucide-react';
+import Header from './Header';
+import { buttonSecondary } from '../lib/buttonStyles';
+
+const NotFoundPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-stone-50 text-stone-800">
+      <Header />
+      <main>
+        <section className="mx-auto flex min-h-[80vh] max-w-screen-md flex-col items-center justify-center px-6 pt-24 pb-16 text-center">
+          <span className="block text-[11px] uppercase tracking-[0.4em] text-earth-sage">Error 404</span>
+          <h1 className="mt-6 font-serif text-5xl leading-tight text-stone-900 md:text-7xl">
+            迷い込んだページの<br />ようです。
+          </h1>
+          <p className="mt-10 max-w-xl text-base leading-loose text-stone-600">
+            お探しのページは見つかりませんでした。
+            <br />
+            目次に戻って、別の章をめくってみてください。
+          </p>
+          <div className="mt-12 flex flex-col gap-3 sm:flex-row">
+            <a href="#" className={`${buttonSecondary} min-w-[200px]`}>
+              ホームへ戻る
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+            <a href="#/works" className={`${buttonSecondary} min-w-[200px]`}>
+              Works を見る
+              <ArrowUpRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default NotFoundPage;

--- a/components/WorksPage.tsx
+++ b/components/WorksPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ArrowUpRight, BookOpenText, Headphones, Landmark, Newspaper, Sparkles } from 'lucide-react';
+import BackToTop from './BackToTop';
 import Header from './Header';
 import { buttonPrimary, buttonPrimaryOnDark, buttonSecondary, buttonSecondaryOnDark } from '../lib/buttonStyles';
 import {
@@ -462,6 +463,7 @@ const WorksPage: React.FC = () => {
           </div>
         </section>
       </main>
+      <BackToTop />
     </div>
   );
 };

--- a/data/press.ts
+++ b/data/press.ts
@@ -1,0 +1,9 @@
+// Press mentions — shared between Home Contact and Media Kit.
+export const pressMentions: string[] = [
+  '美的',
+  '日経x woman',
+  'CREA',
+  'Hanako',
+  'シティリビング',
+  'Voicy',
+];

--- a/index.html
+++ b/index.html
@@ -17,6 +17,31 @@
     <meta name="twitter:title" content="Sensoria - 五感で紡ぐ、美の旅路 -" />
     <meta name="twitter:description" content="五感美容をテーマにした上質なポートフォリオ・Webマガジンサイト。アート、旅、美容を通じた美意識の記録。" />
     <meta name="twitter:image" content="https://sensoria-portfolio.vercel.app/og-image.svg" />
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "name": "Sensoria",
+      "url": "https://sensoria-portfolio.vercel.app/",
+      "description": "五感美容をテーマにした上質なポートフォリオ・Webマガジンサイト。アート、旅、美容を通じた美意識の記録。",
+      "inLanguage": "ja"
+    }
+    </script>
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "Person",
+      "name": "ぺんぺんすけ",
+      "url": "https://sensoria-portfolio.vercel.app/",
+      "jobTitle": "Writer / Editor",
+      "description": "アート、旅、美容をテーマに執筆活動を行うライター・エディター。日本経済新聞電子版にて 300 本以上の記事を執筆。",
+      "knowsAbout": ["美容", "旅", "アート", "ライフスタイル", "編集"],
+      "sameAs": [
+        "https://www.instagram.com/rika05181/"
+      ],
+      "image": "https://sensoria-portfolio.vercel.app/profile-portrait.jpg"
+    }
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>
       tailwind.config = {


### PR DESCRIPTION
## Summary
公開準備を進める Round A 4 件をまとめて適用。

### 内訳
| # | 内容 | 影響範囲 |
|---|---|---|
| 1 | Contact に Press 一覧（媒体名 chip 行）追加 | \`Contact.tsx\`, \`data/press.ts\`（新規）, \`MediaKitPage.tsx\`（共有データ参照に切替） |
| 2 | Back-to-top フローティングボタン | \`BackToTop.tsx\`（新規）, \`WorksPage.tsx\` |
| 3 | カスタム 404 ページ | \`NotFoundPage.tsx\`（新規）, \`App.tsx\`（routing 拡張） |
| 4 | JSON-LD（WebSite / Person） | \`index.html\` |

### 詳細
- **Press 行**: Contact の右カラムの上に小さなキャプション "Press" + 中点区切りの媒体名リスト。社会的証明を CTA の直前に置く編集物パターン
- **Back-to-top**: WorksPage は縦スクロールが長いため、右下に小さな ↑ ボタン。600px 以上スクロールした時のみ表示。Pattern D の Secondary 罫線スタイル
- **404**: 未知の \`#/foo\` で sneaky に home に落ちる挙動を修正。Hero と同じ世界観で「迷い込んだページのようです。」+ Home / Works への戻り CTA を表示
- **JSON-LD**: WebSite（サイト全体）と Person（ぺんぺんすけ）の 2 ブロック。\`sameAs\` で Instagram を関連付け、\`image\` でプロフィール写真を指定

## Test plan
- [x] \`npx tsc --noEmit\` 通過
- [x] \`npm run build\` 成功
- [ ] preview の Contact に Press 行が表示されること
- [ ] preview の Works ページで 600px スクロール後に Back-to-top ボタンが現れること
- [ ] preview で \`#/anything-unknown\` にアクセスすると 404 ページが出ること
- [ ] preview の DevTools で JSON-LD が 2 ブロック読み込まれていること（[Schema.org Validator](https://validator.schema.org/) で検証可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)