### PR TITLE
docs: README全面書き換え（実態反映）+ docs index にspecification.md追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,45 @@
-<div align="center">
-<img width="1200" height="475" alt="GHBanner" src="https://github.com/user-attachments/assets/0aa67016-6eaf-458a-adb2-6e31a0763ed6" />
-</div>
+# Sensoria - 五感で紡ぐ、美の旅路 -
 
-# Run and deploy your AI Studio app
+美容・アート・旅をテーマにした「五感美容」コンセプトの個人ポートフォリオ／Webマガジンサイト。日経Webでの300本超の連載実績を持つ著者の Journal（世界観・実績紹介）/ Works（掲載実績アーカイブ）/ Media Kit（取材・寄稿向け資料）を1つのSPAに集約している。
 
-This contains everything you need to run your app locally.
+詳細な仕様・運用ルールは [`docs/00-index.md`](docs/00-index.md) を入口とする `docs/` 配下のドキュメント群を参照すること。
 
-View your app in AI Studio: https://ai.studio/apps/drive/1zHFskn2xEeDMnGPMxLoFE7oe-UAB_6Pp
+## 技術スタック
 
-## Run Locally
+- [React 19](https://react.dev/) + [TypeScript](https://www.typescriptlang.org/)
+- [Vite 6](https://vitejs.dev/)（ビルド・開発サーバー）
+- [Tailwind CSS](https://tailwindcss.com/)
+- [lucide-react](https://lucide.dev/)（アイコン）
 
-**Prerequisites:**  Node.js
+外部 API・LLM への依存はなし（`GEMINI_API_KEY` 等の環境変数は不要）。
 
+## 開発コマンド
 
-1. Install dependencies:
-   `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
-3. Run the app:
-   `npm run dev`
+```bash
+npm install      # 依存関係のインストール
+npm run dev      # 開発サーバー起動
+npm run build    # 本番ビルド
+npm run preview  # ビルド成果物のローカルプレビュー
+```
+
+## ディレクトリ構成（要点）
+
+```
+App.tsx              # ルーティング（hash ベース）とページ切り替え
+index.tsx            # エントリポイント
+components/          # ページ・セクション単位のコンポーネント
+data/                # works・press など静的コンテンツデータ
+lib/                 # 共通スタイル定義（buttonStyles / surfaces）
+public/               # 静的アセット（favicon, OGP画像, robots.txt, sitemap.xml 等）
+src/index.css         # グローバルスタイル / Tailwind エントリ
+docs/                 # 仕様・設計・運用ドキュメント一式
+specification.md      # デザイン・コンセプトの単票仕様
+```
+
+ルーティングは単一ページ（`/`）+ ハッシュルート構成。`/`（Home）、`/#/works`（Works Page）、`/#/media-kit`（Media Kit Page）が主要な公開ページで、詳細は [`docs/03-page-structure.md`](docs/03-page-structure.md) を参照。
+
+## ドキュメント
+
+作業前に必ず [`docs/00-index.md`](docs/00-index.md)（ドキュメント構成のルールブック）を確認すること。プロジェクト概要・デザイン指針・ページ構造・SEO/計測方針・公開前チェックリスト等はすべて `docs/` 配下の連番ドキュメントにまとまっている。
+
+エージェント／コラボレーション運用ルールは [`AGENTS.md`](AGENTS.md) を参照。

--- a/docs/00-index.md
+++ b/docs/00-index.md
@@ -42,6 +42,7 @@ Reference / Log:
 
 - [concept-spec.md](concept-spec.md) — PoC 期のコンセプト参考資料（凍結）。
 - [project-log20260112.md](project-log20260112.md) — 2026-01-12 時点の作業ログ。
+- [../specification.md](../specification.md) — ルート直下のデザイン・コンセプト単票仕様（凍結。改訂時は `docs/` の Core Spec へ内容を昇格させる方針。§7 参照）。
 
 ## 4. 棲み分けの原則
 


### PR DESCRIPTION
## 変更理由

現状のREADMEはGoogle AI Studioの雛形（"Run and deploy your AI Studio app"、`GEMINI_API_KEY` の設定手順）のまま残っていたが、実際のリポジトリはGemini/LLM依存ゼロ（React 19 + Vite 6 + TypeScript + Tailwind CSS + lucide-react のみ）で、美容・アート・旅の「五感美容」コンセプトを扱うポートフォリオ／Webマガジンサイト（Journal・Works・Media Kit構成）として運用されている。実態と乖離した公開ドキュメントを、docs/ と package.json / src構造から確認できる事実に基づいて書き直した。

`vite.config.ts` にはまだ `GEMINI_API_KEY` を参照する define が残っているが、実際に参照しているコードは存在しない（`.env` ファイルも無い）ことをgrepで確認済み。今回のスコープはREADMEとdocsのみのため、`vite.config.ts` 自体の削除は対象外とした。

## 変更内容

- `README.md`: サイト概要 / 技術スタック / 開発コマンド（`npm run dev` 等）/ ディレクトリ構成の要点 / `docs/00-index.md` への導線に全面書き換え。著者の実名など個人特定情報はdocs内に既にある表現の範囲に留めている。デプロイ先URLは `docs/07-release-checklist.md` 上でも「本番ドメイン未確定」「vercel.appは暫定」と明記されているため記載していない。
- `docs/00-index.md`: Reference / Log 一覧にルート直下の `specification.md` を追記（`docs/00-index.md` §7 に元々「ルートのspecification.mdはReference」という位置づけの記載があったため、それに合わせてReference扱いとした）。

## レビューをお願いしたい点

- サイト概要文の粒度・言葉遣いが公開ページの説明として適切か
- README内の技術スタック・ディレクトリ構成の記載に過不足がないか

**レビュー後にマージしてください。**（公開サイトの説明文のため、マージはユーザー側の確認待ちとします）

## Test plan
- [ ] README.mdの内容がサイトの実態と一致しているかレビュー
- [ ] docs/00-index.mdへのspecification.md追記が既存ルールと整合しているかレビュー

🤖 Generated with [Claude Code](https://claude.com/claude-code)